### PR TITLE
Draft of motor and encoder API

### DIFF
--- a/phidgets_api/CMakeLists.txt
+++ b/phidgets_api/CMakeLists.txt
@@ -15,7 +15,8 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(phidgets_api src/phidget.cpp
                          src/imu.cpp
-                         src/ir.cpp)
+                         src/ir.cpp
+                         src/motor.cpp)
 
 add_dependencies(phidgets_api ${catkin_EXPORTED_TARGETS})
 

--- a/phidgets_api/CMakeLists.txt
+++ b/phidgets_api/CMakeLists.txt
@@ -15,7 +15,8 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(phidgets_api src/phidget.cpp
                          src/imu.cpp
-                         src/ir.cpp)
+                         src/ir.cpp
+                         src/encoder.cpp)
 
 add_dependencies(phidgets_api ${catkin_EXPORTED_TARGETS})
 

--- a/phidgets_api/include/phidgets_api/encoder.h
+++ b/phidgets_api/include/phidgets_api/encoder.h
@@ -1,0 +1,59 @@
+#ifndef PHIDGETS_API_ENCODER_H
+#define PHIDGETS_API_ENCODER_H
+
+#include "phidgets_api/phidget.h"
+
+namespace phidgets {
+
+class Encoder: public Phidget
+{
+  public:
+    Encoder();
+
+    /**@brief Gets the number of digital input channels supported by this board */
+    int getInputCount();
+
+    /** @brief Reads the current state of a digital input
+     * @param index The index of the input to read */
+    bool getInputState(int index);
+
+    /**@brief Gets the number of encoder input channels supported by this board */
+    int getEncoderCount();
+
+    /** @brief Reads the current position of an encoder
+     * @param index The index of the encoder to read */
+    int getPosition(int index);
+
+    /** @brief Sets the offset of an encoder such that current position is the specified value
+     * @param index The index of the encoder to set
+     * @param position The new value that should be returned by 'getPosition(index)' at the current position of the encoder*/
+    void setPosition(int index, int position);
+
+    /** @brief Gets the position of an encoder the last time an index pulse occured. An index pulse in this context refers to an input
+     * from the encoder the pulses high once every revolution.
+     * @param index The index of the encoder to read */
+    int getIndexPosition(int index);
+
+    /** @brief Checks if an encoder is powered on and receiving events
+     * @param index The index of the encoder to check */
+    bool getEnabled(int index);
+
+    /** @brief Set the powered state of an encoder. If an encoder is not enabled, it will not be given
+     * power, and events and changes in position will not be captured.
+     * @param index The index of the encoder to change
+     * @param enabled The new powered state of the encoder*/
+    void setEnabled(int index, bool enabled);
+
+    /* TODO Add set event handlers from phidget api
+     * int CPhidgetEncoder_set_OnInputChange_Handler (CPhidgetEncoderHandle phid, int(*fptr)(CPhidgetEncoderHandle phid, void *userPtr, int index, int inputState), void *userPtr)
+     * int CPhidgetEncoder_set_OnPositionChange_Handler (CPhidgetEncoderHandle phid, int(*fptr)(CPhidgetEncoderHandle phid, void *userPtr, int index, int time, int positionChange), void *userPtr)
+     * int CPhidgetEncoder_set_OnIndex_Handler (CPhidgetEncoderHandle phid, int(*fptr)(CPhidgetEncoderHandle phid, void *userPtr, int index, int indexPosition), void *userPtr)
+     */
+
+  protected:
+    CPhidgetEncoderHandle encoder_handle_;
+};
+
+} //namespace phidgets
+
+#endif // PHIDGETS_API_ENCODEr_H

--- a/phidgets_api/include/phidgets_api/motor.h
+++ b/phidgets_api/include/phidgets_api/motor.h
@@ -1,0 +1,67 @@
+#ifndef PHIDGETS_API_MOTOR_H
+#define PHIDGETS_API_MOTOR_H
+
+#include "phidgets_api/phidget.h"
+
+namespace phidgets {
+
+class MotorController: public Phidget
+{
+  public:
+    MotorController();
+
+    // Motor specific
+    int    getMotorCount();
+    double getVelocity(int index);
+    void   setVelocity(int index, double velocity);
+    double getAcceleration(int index);
+    void   setAcceleration(int index, double acceleration);
+    double getAccelerationMax(int index);
+    double getAccelerationMin(int index);
+    double getCurrent(int index);
+
+    // Digital inputs
+    int  getInputCount();
+    bool getInputState(int index);
+
+    // Encoder inputs
+    int  getEncoderCount();
+    int  getEncoderPosition(int index);
+    void setEncoderPosition(int index, int position);
+
+    // Back EMF
+    int    getBackEMFSensingState(int index);
+    void   setBackEMFSensingState(int index, int bEMFState);
+    double getBackEMF(int index);
+
+    double getSupplyVoltage();
+
+    double getBraking(int index);
+    void   setBraking(int index, double braking);
+
+    // Analog sensors
+    int getSensorCount();
+    int getSensorValue(int index);
+    int getSensorRawValue(int index);
+
+    int  getRatiometric();
+    void setRatiometric(int ratiometric);
+
+    /* TODO Add event handlers from phidget api
+     * int CPhidgetMotorControl_set_OnVelocityChange_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, double velocity), void *userPtr)
+     * int CPhidgetMotorControl_set_OnCurrentChange_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, double current), void *userPtr)
+     * int CPhidgetMotorControl_set_OnInputChange_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, int inputState), void *userPtr)
+     * int CPhidgetMotorControl_set_OnEncoderPositionChange_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, int time, int positionChange), void *userPtr)
+     * int CPhidgetMotorControl_set_OnEncoderPositionUpdate_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, int positionChange), void *userPtr)
+     * int CPhidgetMotorControl_set_OnBackEMFUpdate_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, double voltage), void *userPtr)
+     * int CPhidgetMotorControl_set_OnSensorUpdate_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, int sensorValue), void *userPtr)
+     * int CPhidgetMotorControl_set_OnCurrentUpdate_Handler (CPhidgetMotorControlHandle phid, int(*fptr)(CPhidgetMotorControlHandle phid, void *userPtr, int index, double current), void *userPtr)
+     */
+
+  protected:
+    CPhidgetMotorControlHandle motor_handle_;
+};
+
+} //namespace phidgets
+
+#endif // PHIDGETS_API_MOTOR_H

--- a/phidgets_api/src/encoder.cpp
+++ b/phidgets_api/src/encoder.cpp
@@ -1,0 +1,91 @@
+#include "phidgets_api/encoder.h"
+
+#include <cassert>
+
+namespace phidgets {
+
+Encoder::Encoder():
+  Phidget(),
+  encoder_handle_(0)
+{
+  // create the handle
+  CPhidgetEncoder_create(&encoder_handle_);
+
+  // pass handle to base class
+  Phidget::init((CPhidgetHandle)encoder_handle_);
+
+  // register base class callbacks
+  Phidget::registerHandlers();
+}
+
+int Encoder::getInputCount() {
+    int count;
+    int ret = CPhidgetEncoder_getInputCount(encoder_handle_, &count);
+
+    assert(ret == EPHIDGET_OK);
+
+    return count;
+}
+
+bool Encoder::getInputState(int index) {
+    int state;
+    int ret = CPhidgetEncoder_getInputState(encoder_handle_, index, &state);
+
+    assert(ret == EPHIDGET_OK);
+
+    return state == PTRUE;
+}
+
+int Encoder::getEncoderCount() {
+    int count;
+    int ret = CPhidgetEncoder_getEncoderCount(encoder_handle_, &count);
+
+    assert(ret == EPHIDGET_OK);
+
+    return count;
+}
+
+int Encoder::getPosition(int index) {
+    int position;
+    int ret = CPhidgetEncoder_getPosition(encoder_handle_, index, &position);
+
+    assert(ret == EPHIDGET_OK);
+
+    return position;
+}
+
+void Encoder::setPosition(int index, int position) {
+    int ret = CPhidgetEncoder_setPosition(encoder_handle_, index, position);
+
+    assert(ret == EPHIDGET_OK);
+}
+
+int Encoder::getIndexPosition(int index) {
+    int position;
+    int ret = CPhidgetEncoder_getIndexPosition(encoder_handle_, index, &position);
+
+    // Encoder does not support indexing or index has not occured
+    if(ret == EPHIDGET_UNKNOWNVAL) return 0;
+
+    assert(ret == EPHIDGET_OK);
+
+    return position;
+}
+
+bool Encoder::getEnabled(int index) {
+    int enabled;
+    int ret = CPhidgetEncoder_getEnabled(encoder_handle_, index, &enabled);
+
+    assert(ret == EPHIDGET_OK);
+
+    return enabled == PTRUE;
+}
+
+void Encoder::setEnabled(int index, bool enabled) {
+    int ret = CPhidgetEncoder_setEnabled(encoder_handle_, index, enabled ? PTRUE : PFALSE);
+
+    assert(ret == EPHIDGET_OK);
+}
+
+} //namespace phidgets
+

--- a/phidgets_api/src/motor.cpp
+++ b/phidgets_api/src/motor.cpp
@@ -1,0 +1,132 @@
+#include "phidgets_api/motor.h"
+
+#include <cassert>
+
+// Get and return the value name of type type (I varient is indexed)
+#define GAR(type, name)      type x; int ret = CPhidgetMotorControl_get ## name (motor_handle_, &x); assert(ret == EPHIDGET_OK); return x;
+#define GAR_I(type, name, i) type x; int ret = CPhidgetMotorControl_get ## name (motor_handle_, i, &x); assert(ret == EPHIDGET_OK); return x;
+
+// Set the value name to x (I varient is indexed)
+#define SET(name, x)      int ret = CPhidgetMotorControl_set ## name (motor_handle_, x); assert(ret == EPHIDGET_OK);
+#define SET_I(name, x, i) int ret = CPhidgetMotorControl_set ## name (motor_handle_, i, x); assert(ret == EPHIDGET_OK);
+
+namespace phidgets {
+
+MotorController::MotorController():
+  Phidget(),
+  motor_handle_(0)
+{
+  // create the handle
+  CPhidgetMotorControl_create(&motor_handle_);
+
+  // pass handle to base class
+  Phidget::init((CPhidgetHandle)motor_handle_);
+
+  // register base class callbacks
+  Phidget::registerHandlers();
+}
+
+int MotorController::getMotorCount() {
+    GAR(int, MotorCount);
+}
+
+double MotorController::getVelocity(int index) {
+    GAR_I(double, Velocity, index);
+}
+
+void MotorController::setVelocity(int index, double velocity) {
+    SET_I(Velocity, velocity, index);
+}
+
+double MotorController::getAcceleration(int index) {
+    GAR_I(double, Acceleration, index);
+}
+
+void MotorController::setAcceleration(int index, double acceleration) {
+    SET_I(Acceleration, acceleration, index);
+}
+
+double MotorController::getAccelerationMax(int index) {
+    GAR_I(double, AccelerationMax, index);
+}
+
+double MotorController::getAccelerationMin(int index) {
+    GAR_I(double, AccelerationMin, index);
+}
+
+double MotorController::getCurrent(int index) {
+    GAR_I(double, Current, index);
+}
+
+int MotorController::getInputCount() {
+    GAR(int, InputCount);
+}
+
+bool MotorController::getInputState(int index) {
+    int state;
+    int ret = CPhidgetMotorControl_getInputState(motor_handle_, index, &state);
+
+    assert (ret == EPHIDGET_OK);
+
+    return state == PTRUE;
+}
+
+int MotorController::getEncoderCount() {
+    GAR(int, EncoderCount);
+}
+
+int MotorController::getEncoderPosition(int index) {
+    GAR_I(int, EncoderPosition, index);
+}
+
+void MotorController::setEncoderPosition(int index, int position) {
+    SET_I(EncoderPosition, position, index);
+}
+
+int MotorController::getBackEMFSensingState(int index) {
+    GAR_I(int, BackEMFSensingState, index);
+}
+
+void MotorController::setBackEMFSensingState(int index, int bEMFState) {
+    SET_I(BackEMFSensingState, bEMFState, index);
+}
+
+double MotorController::getBackEMF(int index) {
+    GAR_I(double, BackEMF, index);
+}
+
+double MotorController::getSupplyVoltage() {
+    GAR(double, SupplyVoltage);
+}
+
+double MotorController::getBraking(int index) {
+    GAR_I(double, Braking, index);
+}
+
+void MotorController::setBraking(int index, double braking) {
+    SET_I(Braking, braking, index);
+}
+
+int MotorController::getSensorCount() {
+    GAR(int, SensorCount);
+}
+
+int MotorController::getSensorValue(int index) {
+    GAR_I(int, SensorValue, index);
+}
+
+int MotorController::getSensorRawValue(int index) {
+    GAR_I(int, SensorRawValue, index);
+}
+
+int MotorController::getRatiometric() {
+    GAR(int, Ratiometric);
+}
+
+void MotorController::setRatiometric(int ratiometric) {
+    SET(Ratiometric, ratiometric);
+}
+
+
+} //namespace phidgets
+


### PR DESCRIPTION
I had a couple phidgets lying around that I had been using on a robot doing SLAM, and I figured I'd wrap the API for them. In theory the macros I defined for `MotorController` should generalize to any of the phidget modules. Several of the phidget boards have common elements (digital inputs, encoder inputs, etc.) that might be worth creating interfaces for to try and minimize the amount of redundant code.

I `assert`ed that none of the `libphidget` calls would fail, but it might also be worth implementing a `PhidgetException` to throw in case of library function failures.