### PR TITLE
phidgets_imu: add optional serial number parameter

### DIFF
--- a/phidgets_imu/include/phidgets_imu/imu_ros_i.h
+++ b/phidgets_imu/include/phidgets_imu/imu_ros_i.h
@@ -54,6 +54,7 @@ class ImuRosI : public Imu
     bool initialized_;
     boost::mutex mutex_;
     ros::Time last_imu_time_;
+    int serial_number_;
 
     ImuMsg imu_msg_;
     MagMsg mag_msg_;

--- a/phidgets_imu/launch/imu.launch
+++ b/phidgets_imu/launch/imu.launch
@@ -3,7 +3,7 @@
 <launch>
 
   #### Nodelet manager ######################################################
-<param name="serial_number" value="123456"/>
+
   <node pkg="nodelet" type="nodelet" name="imu_manager" 
     args="manager" output="screen" />
 

--- a/phidgets_imu/launch/imu.launch
+++ b/phidgets_imu/launch/imu.launch
@@ -3,7 +3,7 @@
 <launch>
 
   #### Nodelet manager ######################################################
-
+<param name="serial_number" value="123456"/>
   <node pkg="nodelet" type="nodelet" name="imu_manager" 
     args="manager" output="screen" />
 
@@ -15,6 +15,9 @@
 
     # supported data rates: 4 8 16 24 32 40 ... 1000 (in ms)
     <param name="period" value="4"/>
+
+    # optional param serial_number, default is -1
+    <!-- <param name="serial_number" value="123456"/> -->
 
     # compass correction params (see http://www.phidgets.com/docs/1044_User_Guide)
     <!-- <param name="cc_mag_field" value="0.52859"/>

--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -8,6 +8,7 @@ ImuRosI::ImuRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
   nh_(nh),
   nh_private_(nh_private),
   is_connected_(false),
+  serial_number_(-1),
   error_number_(0),
   target_publish_freq_(0.0),
   initialized_(false)
@@ -26,6 +27,8 @@ ImuRosI::ImuRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
     linear_acceleration_stdev_ = 300.0 * 1e-6 * G; // 300 ug as per manual
   if (!nh_private_.getParam ("magnetic_field_stdev", magnetic_field_stdev_))
     magnetic_field_stdev_ = 0.095 * (M_PI / 180.0); // 0.095°/s as per manual
+  if (nh_private_.getParam ("serial_number", serial_number_)) // optional param serial_number, default is -1
+    ROS_INFO_STREAM("Searching for device with serial number: " << serial_number_);
 
   bool has_compass_params =
       nh_private_.getParam ("cc_mag_field", cc_mag_field_)
@@ -147,8 +150,9 @@ ImuRosI::ImuRosI(ros::NodeHandle nh, ros::NodeHandle nh_private):
 
 void ImuRosI::initDevice()
 {
-	ROS_INFO("Opening device");
-	open(-1);
+	ROS_INFO_STREAM("Opening device");
+
+	open(serial_number_); // optional param serial_number, default is -1
 
 	ROS_INFO("Waiting for IMU to be attached...");
 	int result = waitForAttachment(10000);


### PR DESCRIPTION
This PR adds an optional parameter serial number to the IMU node. If the parameter is set the node will wait for the IMU with the given serial number. If no serial number is given it will use the first IMU which is attached.