### PR TITLE
libphidget21: Update CFLAGS

### DIFF
--- a/libphidget21/CMakeLists.txt
+++ b/libphidget21/CMakeLists.txt
@@ -14,8 +14,7 @@ ExternalProject_Add(EP_${PROJECT_NAME}
     CONFIGURE_COMMAND "./configure"
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src
     BUILD_IN_SOURCE 1
-    # CFLAGS=-w disables all warnings from upstream library (we cannot do anything about them)
-    BUILD_COMMAND make CFLAGS=-w
+    BUILD_COMMAND make "CFLAGS=-g -O2 -Wno-incompatible-pointer-types -Wno-deprecated-declarations"
         # copy headers to devel space (catkin does not like headers in source space)
         COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src/phidget21.h ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
         # copy libs, set-up soname chain


### PR DESCRIPTION
Actually use the CFLAGS from 31ba59e instead of 48008f3.