### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/phidgets_imu/src/phidgets_imu_nodelet.cpp
+++ b/phidgets_imu/src/phidgets_imu_nodelet.cpp
@@ -2,7 +2,7 @@
 
 typedef phidgets::PhidgetsImuNodelet PhidgetsImuNodelet;
 
-PLUGINLIB_DECLARE_CLASS (phidgets_imu, PhidgetsImuNodelet, PhidgetsImuNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(PhidgetsImuNodelet, nodelet::Nodelet)
 
 void PhidgetsImuNodelet::onInit()
 {


### PR DESCRIPTION
These macros deprecated for now 8 years will be removed in the next ROS release (ROS Melodic)
