### PR TITLE
Move from one service per output to a single one

### DIFF
--- a/phidgets_ik/CMakeLists.txt
+++ b/phidgets_ik/CMakeLists.txt
@@ -32,8 +32,8 @@ add_library(phidgets_ik src/ik_ros_i.cpp)
 
 add_executable(phidgets_ik_node src/phidgets_ik_node.cpp)
 
-add_dependencies(phidgets_ik ${catkin_EXPORTED_TARGETS})
-add_dependencies(phidgets_ik_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(phidgets_ik ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(phidgets_ik_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(phidgets_ik ${catkin_LIBRARIES})
 target_link_libraries(phidgets_ik_node ${catkin_LIBRARIES} phidgets_ik)

--- a/phidgets_ik/CMakeLists.txt
+++ b/phidgets_ik/CMakeLists.txt
@@ -6,15 +6,24 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     add_compile_options(-Wall)
 endif()
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs message_generation tf)
 
 find_package(Boost REQUIRED COMPONENTS thread)
+
+add_service_files (
+  FILES
+  SetDigitalOutput.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES phidgets_ik
   DEPENDS Boost
-  CATKIN_DEPENDS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs std_srvs tf
+  CATKIN_DEPENDS geometry_msgs nodelet phidgets_api roscpp sensor_msgs std_msgs message_runtime tf
 )
 
 include_directories(include ${catkin_INCLUDE_DIRS})

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -2,10 +2,10 @@
 #define PHIDGETS_IK_IK_ROS_I_H
 
 #include <ros/ros.h>
+#include <phidgets_api/ik.h>
 #include <std_msgs/Bool.h>
 #include <std_msgs/Float32.h>
-#include <std_srvs/SetBool.h>
-#include <phidgets_api/ik.h>
+#include "phidgets_ik/SetDigitalOutput.h"
 
 #include <vector>
 #include <boost/shared_ptr.hpp>
@@ -16,7 +16,7 @@ class OutputSetter {
   public:
     OutputSetter(CPhidgetInterfaceKitHandle ik_handle, int index);
     virtual void set_msg_callback(const std_msgs::Bool::ConstPtr& msg);
-    virtual bool set_srv_callback(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response &res);
+    virtual bool set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req, phidgets_ik::SetDigitalOutput::Response &res);
     ros::Subscriber subscription;
     ros::ServiceServer service;
   protected:

--- a/phidgets_ik/include/phidgets_ik/ik_ros_i.h
+++ b/phidgets_ik/include/phidgets_ik/ik_ros_i.h
@@ -16,9 +16,7 @@ class OutputSetter {
   public:
     OutputSetter(CPhidgetInterfaceKitHandle ik_handle, int index);
     virtual void set_msg_callback(const std_msgs::Bool::ConstPtr& msg);
-    virtual bool set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req, phidgets_ik::SetDigitalOutput::Response &res);
     ros::Subscriber subscription;
-    ros::ServiceServer service;
   protected:
     int index;
     CPhidgetInterfaceKitHandle ik_handle_;
@@ -38,6 +36,7 @@ class IKRosI : public IK
     int n_sensors;
     std::vector<ros::Publisher> in_pubs_;
     std::vector<ros::Publisher> sensor_pubs_;
+    ros::ServiceServer out_srv_;
     std::vector<boost::shared_ptr<OutputSetter> > out_subs_;
 
   private:
@@ -50,6 +49,8 @@ class IKRosI : public IK
     void initDevice();
     void sensorHandler(int index, int sensorValue);
     void inputHandler(int index, int inputValue);
+
+    bool set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req, phidgets_ik::SetDigitalOutput::Response &res);
 };
 
 } //namespace phidgets

--- a/phidgets_ik/package.xml
+++ b/phidgets_ik/package.xml
@@ -21,7 +21,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>std_srvs</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>tf</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nodelet</run_depend>
@@ -29,6 +29,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>std_srvs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>tf</run_depend>
 </package>

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -47,11 +47,9 @@ void IKRosI::initDevice()
   for (int i = 0; i < n_out; i++) {
     char topicname[] = "digital_output00";
     snprintf(topicname, sizeof(topicname), "digital_output%02d", i);
-    char servicename[] = "set_digital_output00";
-    snprintf(servicename, sizeof(servicename), "set_digital_output%02d", i);
     boost::shared_ptr<OutputSetter> s (new OutputSetter(ik_handle_, i));
     s->subscription = nh_.subscribe(topicname, 1, &OutputSetter::set_msg_callback, s);
-    s->service = nh_.advertiseService(servicename, &OutputSetter::set_srv_callback, s);
+    s->service = nh_.advertiseService("set_digital_output", &OutputSetter::set_srv_callback, s);
     out_subs_.push_back(s);
   }
   for (int i = 0; i < n_sensors; i++) {
@@ -90,11 +88,11 @@ void OutputSetter::set_msg_callback(const std_msgs::Bool::ConstPtr& msg)
   CPhidgetInterfaceKit_setOutputState(ik_handle_, index, msg->data);
 }
 
-bool OutputSetter::set_srv_callback(std_srvs::SetBool::Request& req,
-  std_srvs::SetBool::Response &res)
+bool OutputSetter::set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req,
+  phidgets_ik::SetDigitalOutput::Response &res)
 {
-  ROS_INFO("Setting output %d to %d", index, req.data);
-  res.success = CPhidgetInterfaceKit_setOutputState(ik_handle_, index, req.data);
+  ROS_INFO("Setting output %d to %d", req.index, req.state);
+  res.success = CPhidgetInterfaceKit_setOutputState(ik_handle_, req.index, req.state);
   return true;
 }
 

--- a/phidgets_ik/src/ik_ros_i.cpp
+++ b/phidgets_ik/src/ik_ros_i.cpp
@@ -49,9 +49,9 @@ void IKRosI::initDevice()
     snprintf(topicname, sizeof(topicname), "digital_output%02d", i);
     boost::shared_ptr<OutputSetter> s (new OutputSetter(ik_handle_, i));
     s->subscription = nh_.subscribe(topicname, 1, &OutputSetter::set_msg_callback, s);
-    s->service = nh_.advertiseService("set_digital_output", &OutputSetter::set_srv_callback, s);
     out_subs_.push_back(s);
   }
+  out_srv_ = nh_.advertiseService("set_digital_output", &IKRosI::set_srv_callback, this);
   for (int i = 0; i < n_sensors; i++) {
     char topicname[] = "analog_input00";
     snprintf(topicname, sizeof(topicname), "analog_input%02d", i);
@@ -82,18 +82,18 @@ void IKRosI::inputHandler(int index, int inputValue)
   }
 }
 
+bool IKRosI::set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req,
+  phidgets_ik::SetDigitalOutput::Response &res)
+{
+  ROS_INFO("Setting output %d to %d", req.index, req.state);
+  res.success = !CPhidgetInterfaceKit_setOutputState(ik_handle_, req.index, req.state);
+  return true;
+}
+
 void OutputSetter::set_msg_callback(const std_msgs::Bool::ConstPtr& msg)
 {
   ROS_INFO("Setting output %d to %d", index, msg->data);
   CPhidgetInterfaceKit_setOutputState(ik_handle_, index, msg->data);
-}
-
-bool OutputSetter::set_srv_callback(phidgets_ik::SetDigitalOutput::Request& req,
-  phidgets_ik::SetDigitalOutput::Response &res)
-{
-  ROS_INFO("Setting output %d to %d", req.index, req.state);
-  res.success = CPhidgetInterfaceKit_setOutputState(ik_handle_, req.index, req.state);
-  return true;
 }
 
 OutputSetter::OutputSetter(CPhidgetInterfaceKitHandle ik_handle, int index)
@@ -103,4 +103,3 @@ OutputSetter::OutputSetter(CPhidgetInterfaceKitHandle ik_handle, int index)
 }
 
 } // namespace phidgets
-

--- a/phidgets_ik/srv/SetDigitalOutput.srv
+++ b/phidgets_ik/srv/SetDigitalOutput.srv
@@ -1,0 +1,4 @@
+uint16 index # index of the output which state is defined
+bool state
+---
+bool success


### PR DESCRIPTION
This is a proposed solution to #23.

It uses a new service type `SetDigitalOutput` with the following definition:

```
uint16 index # index of the output which state is defined
bool state
---
bool success
```