### PR TITLE
Ensure strictly ordered timestamps.

### DIFF
--- a/phidgets_imu/include/phidgets_imu/imu_ros_i.h
+++ b/phidgets_imu/include/phidgets_imu/imu_ros_i.h
@@ -19,6 +19,7 @@ using namespace std;
 namespace phidgets {
 
 const float G = 9.81;
+const float MAX_TIMEDIFF_SECONDS = 0.1;
 
 class ImuRosI : public Imu
 {
@@ -54,6 +55,7 @@ class ImuRosI : public Imu
     bool initialized_;
     boost::mutex mutex_;
     ros::Time last_imu_time_;
+    ros::Time last_published_time_;
     int serial_number_;
 
     ImuMsg imu_msg_;

--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -222,7 +222,7 @@ void ImuRosI::processImuData(CPhidgetSpatial_SpatialEventDataHandle* data, int i
   // Ensure that we only publish strictly ordered timestamps,
   // also in case a time reset happened.
   if (time_now <= last_published_time_) {
-    ROS_WARN_THROTTLE(MAX_TIMEDIFF_SECONDS, "Ignoring data with to out-of-order time.");
+    ROS_WARN_THROTTLE(MAX_TIMEDIFF_SECONDS, "Ignoring data with out-of-order time.");
     return;
   }
 

--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -204,9 +204,9 @@ void ImuRosI::processImuData(CPhidgetSpatial_SpatialEventDataHandle* data, int i
 
   ros::Time time_now = time_zero_ + time_imu;
 
-  double timediff = time_now.toSec() - ros::Time::now().toSec();
-  if (fabs(timediff) > 0.1) {
-    ROS_WARN("IMU time lags behind by %f seconds, resetting IMU time offset!", timediff);
+  double timediff_seconds = time_now.toSec() - ros::Time::now().toSec();
+  if (fabs(timediff_seconds) > MAX_TIMEDIFF_SECONDS) {
+    ROS_WARN("IMU time differs by %f seconds, resetting IMU time offset!", timediff_seconds);
     time_zero_ = ros::Time::now() - time_imu;
     time_now = ros::Time::now();
   }
@@ -217,6 +217,13 @@ void ImuRosI::processImuData(CPhidgetSpatial_SpatialEventDataHandle* data, int i
   {
     last_imu_time_ = time_now;
     initialized_ = true;
+  }
+
+  // Ensure that we only publish strictly ordered timestamps,
+  // also in case a time reset happened.
+  if (time_now <= last_published_time_) {
+    ROS_WARN_THROTTLE(MAX_TIMEDIFF_SECONDS, "Ignoring data with to out-of-order time.");
+    return;
   }
 
   // **** create and publish imu message
@@ -266,6 +273,8 @@ void ImuRosI::processImuData(CPhidgetSpatial_SpatialEventDataHandle* data, int i
 
   // diagnostics
   diag_updater_.update();
+
+  last_published_time_ = time_now;
 }
 
 void ImuRosI::dataHandler(CPhidgetSpatial_SpatialEventDataHandle *data, int count)


### PR DESCRIPTION
Time resets can lead to unordered ROS timestamps.
This patch ensures that such unordered messages are not published,
as this can break subscribers that (correctly) assume strict time ordering.

Fixes #17.