### PR TITLE
Add parameter use_imu_time (default true)

### DIFF
--- a/phidgets_imu/include/phidgets_imu/imu_ros_i.h
+++ b/phidgets_imu/include/phidgets_imu/imu_ros_i.h
@@ -69,6 +69,7 @@ class ImuRosI : public Imu
     double angular_velocity_stdev_;
     double linear_acceleration_stdev_;
     double magnetic_field_stdev_;
+    bool use_imu_time_;
 
     // compass correction params (see http://www.phidgets.com/docs/1044_User_Guide)
     double cc_mag_field_;


### PR DESCRIPTION
Setting use_imu_time to false will disable the imu time calibration and
always use the Host time, i.e. ros::Time::now().