### PR TITLE
phidgets_high_speed_encoder: fix missing tick2rad values

### DIFF
--- a/phidgets_high_speed_encoder/src/phidgets_high_speed_encoder.cpp
+++ b/phidgets_high_speed_encoder/src/phidgets_high_speed_encoder.cpp
@@ -149,8 +149,8 @@ int main(int argc, char *argv[])
   ros::NodeHandle n;
   ros::NodeHandle nh("~");
 
-  std::vector<std::string> joint_names = { "joint0", "joint1", "joint2", "joint3"};
-  std::vector<double>      joint_tick2rad = { 4, 1.0};
+  std::vector<std::string> joint_names = { "joint0", "joint1", "joint2", "joint3" };
+  std::vector<double>      joint_tick2rad = { 1.0, 1.0, 1.0, 1.0 };
   for (unsigned int i = 0; i < joint_names.size(); i++)
   {
     char str[100];


### PR DESCRIPTION
Was causing some strange readings from each joint, with 4x values on first port (joint0), proper readings on second (joint1), and very strange high negative numbers on 3rd and 4th.

See: https://www.phidgets.com/phorum/viewtopic.php?f=18&t=9150