### PR TITLE
Add missing OnInputChange handler

### DIFF
--- a/phidgets_api/src/ik.cpp
+++ b/phidgets_api/src/ik.cpp
@@ -17,6 +17,7 @@ IK::IK():
 
   // register ik data callback
   CPhidgetInterfaceKit_set_OnSensorChange_Handler(ik_handle_, SensorHandler, this);
+  CPhidgetInterfaceKit_set_OnInputChange_Handler(ik_handle_, InputHandler, this);
 }
 
 


### PR DESCRIPTION
The phidgets api is not registering the InputHandler, which needs to be registered for the inputs of the interface kit to work.