### PR TITLE
Update libphidget to version 2.1.9.20190409

### DIFF
--- a/libphidget21/CMakeLists.txt
+++ b/libphidget21/CMakeLists.txt
@@ -8,8 +8,8 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 
 include(ExternalProject)
 ExternalProject_Add(EP_${PROJECT_NAME}
-    URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.8.20151217.tar.gz
-    URL_MD5 818ab2ff1de92ed9568a206e0e89657f
+    URL https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.9.20190409.tar.gz
+    URL_MD5 1149757d0b0483520c6b7525d2d62f7d
 
     CONFIGURE_COMMAND "./configure"
     SOURCE_DIR ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-src


### PR DESCRIPTION
This pull request updates  libphidget to version 2.1.9.20190409, in order to add support for the 1044_1B IMU.

[Product page for 1044_1B IMU](https://www.phidgets.com/?tier=3&catid=10&pcid=8&prodid=1158)

I recently acquired one of these IMUs, installed `ros-kinetic-phidgets-drivers` from apt, and ran 
`roslaunch phidgets_imu imu.launch`
This failed with the error:
`Problem waiting for IMU attachment: Given timeout has been exceeded.`

Investigating, I noticed that the libphidget version used was quite old (2015), and that the source for that version contained no mention of my IMU model (1044_1).  The most recent 2.1.x version does make some specific mentions of this device, so I suppose support was added sometime between 2015 and now.

After making the changes from this PR, and rebuilding, I could successfully connect to the IMU.

I thought I'd offer this change as a PR, although I'm not really sure whether this will affect support for other devices, or how that could be tested. 