### PR TITLE
Fix wrong defaults for standard deviations

### DIFF
--- a/phidgets_imu/include/phidgets_imu/imu_ros_i.h
+++ b/phidgets_imu/include/phidgets_imu/imu_ros_i.h
@@ -16,7 +16,7 @@
 
 namespace phidgets {
 
-const float G = 9.81;
+const float G = 9.80665;
 const float MAX_TIMEDIFF_SECONDS = 0.1;
 
 class ImuRosI final : public Imu

--- a/phidgets_imu/src/imu_ros_i.cpp
+++ b/phidgets_imu/src/imu_ros_i.cpp
@@ -26,18 +26,19 @@ ImuRosI::ImuRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
     if (!nh_private_.getParam("angular_velocity_stdev",
                               angular_velocity_stdev_))
     {
-        angular_velocity_stdev_ =
-            0.02 * (M_PI / 180.0);  // 0.02 deg/s resolution, as per manual
+        // 0.095 deg/s gyroscope white noise sigma, as per manual
+        angular_velocity_stdev_ = 0.095 * (M_PI / 180.0);
     }
     if (!nh_private_.getParam("linear_acceleration_stdev",
                               linear_acceleration_stdev_))
     {
-        linear_acceleration_stdev_ = 300.0 * 1e-6 * G;  // 300 ug as per manual
+        // 280 ug accelerometer white noise sigma, as per manual
+        linear_acceleration_stdev_ = 280.0 * 1e-6 * G;
     }
     if (!nh_private_.getParam("magnetic_field_stdev", magnetic_field_stdev_))
     {
-        magnetic_field_stdev_ =
-            0.095 * (M_PI / 180.0);  // 0.095°/s as per manual
+        // 1.1 milligauss magnetometer white noise sigma, as per manual
+        magnetic_field_stdev_ = 1.1 * 1e-3 * 1e-4;
     }
     if (nh_private_.getParam(
             "serial_number",


### PR DESCRIPTION
The old parameter defaults were wrong:

| parameter                 | old default                       | new default                        |
|---------------------------|-----------------------------------|------------------------------------|
| angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
| linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
| magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T         (= 1.1 mG)       |

Notes: T = Tesla, mG = milligauss

Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32