### PR TITLE
Improve the IMU calibration service

### DIFF
--- a/phidgets_gyroscope/src/gyroscope_ros_i.cpp
+++ b/phidgets_gyroscope/src/gyroscope_ros_i.cpp
@@ -124,7 +124,8 @@ GyroscopeRosI::GyroscopeRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
 
         gyroscope_->setDataInterval(data_interval_ms);
 
-        cal_publisher_ = nh_.advertise<std_msgs::Bool>("imu/is_calibrated", 5);
+        cal_publisher_ = nh_.advertise<std_msgs::Bool>("imu/is_calibrated", 5,
+                                                       true /* latched */);
 
         calibrate();
 
@@ -148,9 +149,14 @@ GyroscopeRosI::GyroscopeRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
 
 void GyroscopeRosI::calibrate()
 {
-    ROS_INFO("Calibrating IMU...");
+    ROS_INFO(
+        "Calibrating Gyro, this takes around 2 seconds to finish. "
+        "Make sure that the device is not moved during this time.");
     gyroscope_->zero();
-    ROS_INFO("Calibrating IMU done.");
+    // The API call returns directly, so we "enforce" the recommended 2 sec
+    // here. See: https://github.com/ros-drivers/phidgets_drivers/issues/40
+    ros::Duration(2.).sleep();
+    ROS_INFO("Calibrating Gyro done.");
 
     // publish message
     std_msgs::Bool is_calibrated_msg;

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -179,7 +179,8 @@ SpatialRosI::SpatialRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
 
         imu_pub_ = nh_.advertise<sensor_msgs::Imu>("imu/data_raw", 1);
 
-        cal_publisher_ = nh_.advertise<std_msgs::Bool>("imu/is_calibrated", 5);
+        cal_publisher_ = nh_.advertise<std_msgs::Bool>("imu/is_calibrated", 5,
+                                                       true /* latched */);
 
         calibrate();
 
@@ -222,9 +223,14 @@ bool SpatialRosI::calibrateService(std_srvs::Empty::Request &req,
 
 void SpatialRosI::calibrate()
 {
-    ROS_INFO("Calibrating Gyro...");
+    ROS_INFO(
+        "Calibrating IMU, this takes around 2 seconds to finish. "
+        "Make sure that the device is not moved during this time.");
     spatial_->zero();
-    ROS_INFO("Calibrating Gyro done.");
+    // The API call returns directly, so we "enforce" the recommended 2 sec
+    // here. See: https://github.com/ros-drivers/phidgets_drivers/issues/40
+    ros::Duration(2.).sleep();
+    ROS_INFO("Calibrating IMU done.");
 
     // publish message
     std_msgs::Bool is_calibrated_msg;


### PR DESCRIPTION
* Change misleading IMU calibration log message.
* Block 2 seconds in IMU calibration handler.
* Make is_calibrated topic latched