### PR TITLE
Fix wrong defaults for standard deviations

### DIFF
--- a/phidgets_accelerometer/include/phidgets_accelerometer/accelerometer_ros_i.h
+++ b/phidgets_accelerometer/include/phidgets_accelerometer/accelerometer_ros_i.h
@@ -40,7 +40,7 @@
 
 namespace phidgets {
 
-const double G = 9.81;
+const double G = 9.80665;
 
 class AccelerometerRosI final
 {

--- a/phidgets_accelerometer/launch/accelerometer.launch
+++ b/phidgets_accelerometer/launch/accelerometer.launch
@@ -24,8 +24,8 @@
     # optional param frame_id, default is "imu_link"
     <!-- <param name="frame_id" value="imu_link"/> -->
 
-    # optional param linear_acceleration_stdev, default is 300ug
-    <!-- <param name="linear_acceleration_stdev" value="0.002943"/> -->
+    # optional param linear_acceleration_stdev, default is 280ug
+    <!-- <param name="linear_acceleration_stdev" value="0.002745862"/> -->
 
     # supported data rates: 4 8 16 24 32 40 ... 1000 (in ms)
     <param name="data_interval_ms" value="4"/>

--- a/phidgets_accelerometer/src/accelerometer_ros_i.cpp
+++ b/phidgets_accelerometer/src/accelerometer_ros_i.cpp
@@ -64,7 +64,8 @@ AccelerometerRosI::AccelerometerRosI(ros::NodeHandle nh,
     if (!nh_private_.getParam("linear_acceleration_stdev",
                               linear_acceleration_stdev))
     {
-        linear_acceleration_stdev = 300.0 * 1e-6 * G;  // 300 ug as per manual
+        // 280 ug accelerometer white noise sigma, as per manual
+        linear_acceleration_stdev = 280.0 * 1e-6 * G;
     }
     linear_acceleration_variance_ =
         linear_acceleration_stdev * linear_acceleration_stdev;

--- a/phidgets_gyroscope/README.md
+++ b/phidgets_gyroscope/README.md
@@ -17,7 +17,7 @@ Parameters
 * `serial` (int) - The serial number of the phidgets gyroscope to connect to.  If -1 (the default), connects to any gyroscope phidget that can be found.
 * `hub_port` (int) - The phidgets VINT hub port to connect to.  Only used if the gyroscope phidget is connected to a VINT hub.  Defaults to 0.
 * `frame_id` (string) - The header frame ID to use when publishing the message.  Defaults to [REP-0145](http://www.ros.org/reps/rep-0145.html) compliant `imu_link`.
-* `angular_velocity_stdev` (double) - The standard deviation to use for the angular velocity when publishing the message.  Defaults to 0.02 deg/s.
+* `angular_velocity_stdev` (double) - The standard deviation to use for the angular velocity when publishing the message.  Defaults to 0.095deg/s.
 * `time_resynchronization_interval_ms` (int) - The number of milliseconds to wait between resynchronizing the time on the Phidgets spatial with the local time.  Larger values have less "jumps", but will have more timestamp drift.  Setting this to 0 disables resynchronization.  Defaults to 5000 ms.
 * `data_interval_ms` (int) - The number of milliseconds between acquisitions of data on the device.  Defaults to 8 ms.
 * `callback_delta_epsilon_ms` (int) - The number of milliseconds epsilon allowed between callbacks when attempting to resynchronize the time.  If this is set to 1, then a difference of `data_interval_ms` plus or minus 1 millisecond will be considered viable for resynchronization.  Higher values give the code more leeway to resynchronize, at the cost of potentially getting bad resynchronizations sometimes.  Lower values can give better results, but can also result in never resynchronizing.  Must be less than `data_interval_ms`.  Defaults to 1 ms.

--- a/phidgets_gyroscope/launch/gyroscope.launch
+++ b/phidgets_gyroscope/launch/gyroscope.launch
@@ -24,8 +24,8 @@
     # optional param frame_id, default is "imu_link"
     <!-- <param name="frame_id" value="imu_link"/> -->
 
-    # optional param angular_velocity_stdev, default is 0.02 deg/s
-    <!-- <param name="angular_velocity_stdev" value="0.000349" /> -->
+    # optional param angular_velocity_stdev, default is 0.095deg/s
+    <!-- <param name="angular_velocity_stdev" value="0.001658" /> -->
 
     # supported data rates: 4 8 16 24 32 40 ... 1000 (in ms)
     <param name="data_interval_ms" value="4"/>

--- a/phidgets_gyroscope/src/gyroscope_ros_i.cpp
+++ b/phidgets_gyroscope/src/gyroscope_ros_i.cpp
@@ -64,8 +64,8 @@ GyroscopeRosI::GyroscopeRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
     double angular_velocity_stdev;
     if (!nh_private_.getParam("angular_velocity_stdev", angular_velocity_stdev))
     {
-        angular_velocity_stdev =
-            0.02 * (M_PI / 180.0);  // 0.02 deg/s resolution, as per manual
+        // 0.095 deg/s gyroscope white noise sigma, as per manual
+        angular_velocity_stdev = 0.095 * (M_PI / 180.0);
     }
     angular_velocity_variance_ =
         angular_velocity_stdev * angular_velocity_stdev;

--- a/phidgets_magnetometer/README.md
+++ b/phidgets_magnetometer/README.md
@@ -12,7 +12,7 @@ Parameters
 * `serial` (int) - The serial number of the phidgets magnetometer to connect to.  If -1 (the default), connects to any magnetometer phidget that can be found.
 * `hub_port` (int) - The phidgets VINT hub port to connect to.  Only used if the magnetometer phidget is connected to a VINT hub.  Defaults to 0.
 * `frame_id` (string) - The header frame ID to use when publishing the message.  Defaults to [REP-0145](http://www.ros.org/reps/rep-0145.html) compliant `imu_link`.
-* `magnetic_field_stdev` - The standard deviation to use for the magnetic field when publishing the message.  Defaults to 0.095 deg/s.
+* `magnetic_field_stdev` - The standard deviation to use for the magnetic field when publishing the message.  Defaults to 1.1 milligauss.
 * `time_resynchronization_interval_ms` (int) - The number of milliseconds to wait between resynchronizing the time on the Phidgets spatial with the local time.  Larger values have less "jumps", but will have more timestamp drift.  Setting this to 0 disables resynchronization.  Defaults to 5000 ms.
 * `data_interval_ms` (int) - The number of milliseconds between acquisitions of data on the device.  Defaults to 8 ms.
 * `callback_delta_epsilon_ms` (int) - The number of milliseconds epsilon allowed between callbacks when attempting to resynchronize the time.  If this is set to 1, then a difference of `data_interval_ms` plus or minus 1 millisecond will be considered viable for resynchronization.  Higher values give the code more leeway to resynchronize, at the cost of potentially getting bad resynchronizations sometimes.  Lower values can give better results, but can also result in never resynchronizing.  Must be less than `data_interval_ms`.  Defaults to 1 ms.

--- a/phidgets_magnetometer/launch/magnetometer.launch
+++ b/phidgets_magnetometer/launch/magnetometer.launch
@@ -24,8 +24,8 @@
     # optional param frame_id, default is "imu_link"
     <!-- <param name="frame_id" value="imu_link"/> -->
 
-    # optional param magnetic_field_stdev, default is 0.095 deg/s
-    <!-- <param name="magnetic_field_stdev" value="0.001658" /> -->
+    # optional param magnetic_field_stdev, default is 1.1 milligauss
+    <!-- <param name="magnetic_field_stdev" type="double" value="1.1e-7" /> -->
 
     # supported data rates: 4 8 16 24 32 40 ... 1000 (in ms)
     <param name="data_interval_ms" value="4"/>

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -63,8 +63,8 @@ MagnetometerRosI::MagnetometerRosI(ros::NodeHandle nh,
     double magnetic_field_stdev;
     if (!nh_private_.getParam("magnetic_field_stdev", magnetic_field_stdev))
     {
-        magnetic_field_stdev =
-            0.095 * (M_PI / 180.0);  // 0.095°/s as per manual
+        // 1.1 milligauss magnetometer white noise sigma, as per manual
+        magnetic_field_stdev = 1.1 * 1e-3 * 1e-4;
     }
     magnetic_field_variance_ = magnetic_field_stdev * magnetic_field_stdev;
 

--- a/phidgets_spatial/README.md
+++ b/phidgets_spatial/README.md
@@ -18,9 +18,9 @@ Parameters
 * `serial` (int) - The serial number of the phidgets spatial to connect to.  If -1 (the default), connects to any spatial phidget that can be found.
 * `hub_port` (int) - The phidgets VINT hub port to connect to.  Only used if the spatial phidget is connected to a VINT hub.  Defaults to 0.
 * `frame_id` (string) - The header frame ID to use when publishing the message.  Defaults to [REP-0145](http://www.ros.org/reps/rep-0145.html) compliant `imu_link`.
-* `linear_acceleration_stdev` (double) - The standard deviation to use for the linear acceleration when publishing the message.  Defaults to 300 ug.
-* `angular_velocity_stdev` (double) - The standard deviation to use for the angular velocity when publishing the message.  Defaults to 0.02 deg/s.
-* `magnetic_field_stdev` (double) - The standard deviation to use for the magnetic field when publishing the message.  Defaults to 0.095 deg/s.
+* `linear_acceleration_stdev` (double) - The standard deviation to use for the linear acceleration when publishing the message.  Defaults to 280 ug.
+* `angular_velocity_stdev` (double) - The standard deviation to use for the angular velocity when publishing the message.  Defaults to 0.095 deg/s.
+* `magnetic_field_stdev` (double) - The standard deviation to use for the magnetic field when publishing the message.  Defaults to 1.1 milligauss.
 * `time_resynchronization_interval_ms` (int) - The number of milliseconds to wait between resynchronizing the time on the Phidgets spatial with the local time.  Larger values have less "jumps", but will have more timestamp drift.  Setting this to 0 disables resynchronization.  Defaults to 5000 ms.
 * `data_interval_ms` (int) - The number of milliseconds between acquisitions of data on the device.  Defaults to 8 ms.
 * `callback_delta_epsilon_ms` (int) - The number of milliseconds epsilon allowed between callbacks when attempting to resynchronize the time.  If this is set to 1, then a difference of `data_interval_ms` plus or minus 1 millisecond will be considered viable for resynchronization.  Higher values give the code more leeway to resynchronize, at the cost of potentially getting bad resynchronizations sometimes.  Lower values can give better results, but can also result in never resynchronizing.  Must be less than `data_interval_ms`.  Defaults to 1 ms.

--- a/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.h
+++ b/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.h
@@ -42,7 +42,7 @@
 
 namespace phidgets {
 
-const float G = 9.81;
+const float G = 9.80665;
 
 class SpatialRosI final
 {

--- a/phidgets_spatial/launch/spatial.launch
+++ b/phidgets_spatial/launch/spatial.launch
@@ -24,14 +24,14 @@
     # optional param frame_id, default is "imu_link"
     <!-- <param name="frame_id" value="imu_link"/> -->
 
-    # optional param linear_acceleration_stdev, default is 300ug
-    <!-- <param name="linear_acceleration_stdev" value="0.002943"/> -->
+    # optional param linear_acceleration_stdev, default is 280ug
+    <!-- <param name="linear_acceleration_stdev" value="0.002745862"/> -->
 
-    # optional param angular_velocity_stdev, default is 0.02 deg/s
+    # optional param angular_velocity_stdev, default is 0.095 deg/s
     <!-- <param name="angular_velocity_stdev" value="0.000349" /> -->
 
-    # optional param magnetic_field_stdev, default is 0.095 deg/s
-    <!-- <param name="magnetic_field_stdev" value="0.001658" /> -->
+    # optional param magnetic_field_stdev, default is 1.1 milligauss
+    <!-- <param name="magnetic_field_stdev" type="double" value="1.1e-7" /> -->
 
     # supported data rates: 4 8 16 24 32 40 ... 1000 (in ms)
     <param name="data_interval_ms" value="4"/>

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -69,7 +69,8 @@ SpatialRosI::SpatialRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
     if (!nh_private_.getParam("linear_acceleration_stdev",
                               linear_acceleration_stdev))
     {
-        linear_acceleration_stdev = 300.0 * 1e-6 * G;  // 300 ug as per manual
+        // 280 ug accelerometer white noise sigma, as per manual
+        linear_acceleration_stdev = 280.0 * 1e-6 * G;
     }
     linear_acceleration_variance_ =
         linear_acceleration_stdev * linear_acceleration_stdev;
@@ -77,8 +78,8 @@ SpatialRosI::SpatialRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
     double angular_velocity_stdev;
     if (!nh_private_.getParam("angular_velocity_stdev", angular_velocity_stdev))
     {
-        angular_velocity_stdev =
-            0.02 * (M_PI / 180.0);  // 0.02 deg/s resolution, as per manual
+        // 0.095 deg/s gyroscope white noise sigma, as per manual
+        angular_velocity_stdev = 0.095 * (M_PI / 180.0);
     }
     angular_velocity_variance_ =
         angular_velocity_stdev * angular_velocity_stdev;
@@ -86,8 +87,8 @@ SpatialRosI::SpatialRosI(ros::NodeHandle nh, ros::NodeHandle nh_private)
     double magnetic_field_stdev;
     if (!nh_private_.getParam("magnetic_field_stdev", magnetic_field_stdev))
     {
-        magnetic_field_stdev =
-            0.095 * (M_PI / 180.0);  // 0.095°/s as per manual
+        // 1.1 milligauss magnetometer white noise sigma, as per manual
+        magnetic_field_stdev = 1.1 * 1e-3 * 1e-4;
     }
     magnetic_field_variance_ = magnetic_field_stdev * magnetic_field_stdev;
 


### PR DESCRIPTION
The old parameter defaults were wrong:

| parameter                 | old default                       | new default                        |
|---------------------------|-----------------------------------|------------------------------------|
| angular_velocity_stdev    | 0.000349056 rad/s (= 0.02 deg/s)  | 0.001658 rad/s    (= 0.095deg/s)   |
| linear_acceleration_stdev | 0.002943 m/s^2 (= 0.0003 g)       | 0.002745862 m/s^2 (= 0.00028 g)    |
| magnetic_field_stdev      | 0.001658 rad/s (= 0.095deg/s)     | 1.1e-7 T          (= 1.1 mG)       |

Notes: T = Tesla, mG = milligauss

Specifications come from the PhidgetSpatial Precision 3/3/3 1044_0 data sheet: https://www.phidgets.com/?&prodid=32