### PR TITLE
Allow multiple hub ports per node

### DIFF
--- a/phidgets_api/include/phidgets_api/accelerometer.hpp
+++ b/phidgets_api/include/phidgets_api/accelerometer.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Accelerometer final
+class Accelerometer final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Accelerometer)
@@ -49,8 +49,6 @@ class Accelerometer final
 
     ~Accelerometer();
 
-    int32_t getSerialNumber() const noexcept;
-
     void getAcceleration(double &x, double &y, double &z,
                          double &timestamp) const;
 
@@ -59,7 +57,6 @@ class Accelerometer final
     void dataHandler(const double acceleration[3], double timestamp) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetAccelerometerHandle accel_handle_;
 

--- a/phidgets_api/include/phidgets_api/accelerometer.hpp
+++ b/phidgets_api/include/phidgets_api/accelerometer.hpp
@@ -44,7 +44,7 @@ class Accelerometer final
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Accelerometer)
 
     explicit Accelerometer(
-        int32_t serial_number, int hub_port, bool is_hub_port_device,
+        const ChannelAddress &channel_address,
         std::function<void(const double[3], double)> data_handler);
 
     ~Accelerometer();
@@ -59,7 +59,7 @@ class Accelerometer final
     void dataHandler(const double acceleration[3], double timestamp) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetAccelerometerHandle accel_handle_;
 

--- a/phidgets_api/include/phidgets_api/analog_input.hpp
+++ b/phidgets_api/include/phidgets_api/analog_input.hpp
@@ -43,8 +43,7 @@ class AnalogInput final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(AnalogInput)
 
-    explicit AnalogInput(int32_t serial_number, int hub_port,
-                         bool is_hub_port_device, int channel,
+    explicit AnalogInput(const ChannelAddress &channel_address,
                          std::function<void(int, double)> input_handler);
 
     ~AnalogInput();
@@ -58,8 +57,7 @@ class AnalogInput final
     void voltageChangeHandler(double sensorValue) const;
 
   private:
-    int32_t serial_number_;
-    int channel_;
+    ChannelAddress channel_address_;
     std::function<void(int, double)> input_handler_;
     PhidgetVoltageInputHandle ai_handle_;
 

--- a/phidgets_api/include/phidgets_api/analog_input.hpp
+++ b/phidgets_api/include/phidgets_api/analog_input.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class AnalogInput final
+class AnalogInput final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(AnalogInput)
@@ -48,8 +48,6 @@ class AnalogInput final
 
     ~AnalogInput();
 
-    int32_t getSerialNumber() const noexcept;
-
     double getSensorValue() const;
 
     void setDataInterval(uint32_t data_interval_ms) const;
@@ -57,7 +55,6 @@ class AnalogInput final
     void voltageChangeHandler(double sensorValue) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(int, double)> input_handler_;
     PhidgetVoltageInputHandle ai_handle_;
 

--- a/phidgets_api/include/phidgets_api/digital_input.hpp
+++ b/phidgets_api/include/phidgets_api/digital_input.hpp
@@ -43,8 +43,7 @@ class DigitalInput
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(DigitalInput)
 
-    explicit DigitalInput(int32_t serial_number, int hub_port,
-                          bool is_hub_port_device, int channel,
+    explicit DigitalInput(const ChannelAddress &channel_address,
                           std::function<void(int, int)> input_handler);
 
     ~DigitalInput();
@@ -56,8 +55,7 @@ class DigitalInput
     void stateChangeHandler(int state) const;
 
   private:
-    int32_t serial_number_;
-    int channel_;
+    ChannelAddress channel_address_;
     std::function<void(int, int)> input_handler_;
     PhidgetDigitalInputHandle di_handle_;
 

--- a/phidgets_api/include/phidgets_api/digital_input.hpp
+++ b/phidgets_api/include/phidgets_api/digital_input.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class DigitalInput
+class DigitalInput : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(DigitalInput)
@@ -48,14 +48,11 @@ class DigitalInput
 
     ~DigitalInput();
 
-    int32_t getSerialNumber() const noexcept;
-
     bool getInputValue() const;
 
     void stateChangeHandler(int state) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(int, int)> input_handler_;
     PhidgetDigitalInputHandle di_handle_;
 

--- a/phidgets_api/include/phidgets_api/digital_output.hpp
+++ b/phidgets_api/include/phidgets_api/digital_output.hpp
@@ -41,8 +41,7 @@ class DigitalOutput final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(DigitalOutput)
 
-    explicit DigitalOutput(int32_t serial_number, int hub_port,
-                           bool is_hub_port_device, int channel);
+    explicit DigitalOutput(const ChannelAddress &channel_address);
 
     ~DigitalOutput();
 
@@ -51,7 +50,7 @@ class DigitalOutput final
     void setOutputState(bool state) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     PhidgetDigitalOutputHandle do_handle_;
 };
 

--- a/phidgets_api/include/phidgets_api/digital_output.hpp
+++ b/phidgets_api/include/phidgets_api/digital_output.hpp
@@ -36,7 +36,7 @@
 
 namespace phidgets {
 
-class DigitalOutput final
+class DigitalOutput final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(DigitalOutput)
@@ -45,12 +45,9 @@ class DigitalOutput final
 
     ~DigitalOutput();
 
-    int32_t getSerialNumber() const noexcept;
-
     void setOutputState(bool state) const;
 
   private:
-    ChannelAddress channel_address_;
     PhidgetDigitalOutputHandle do_handle_;
 };
 

--- a/phidgets_api/include/phidgets_api/encoder.hpp
+++ b/phidgets_api/include/phidgets_api/encoder.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Encoder final
+class Encoder final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Encoder)
@@ -48,8 +48,6 @@ class Encoder final
         std::function<void(int, int, double, int)> position_change_handler);
 
     ~Encoder();
-
-    int32_t getSerialNumber() const noexcept;
 
     /** @brief Reads the current position of an encoder
      */
@@ -81,7 +79,6 @@ class Encoder final
                                int index_triggered);
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(int, int, double, int)> position_change_handler_;
     PhidgetEncoderHandle encoder_handle_;
 

--- a/phidgets_api/include/phidgets_api/encoder.hpp
+++ b/phidgets_api/include/phidgets_api/encoder.hpp
@@ -44,8 +44,7 @@ class Encoder final
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Encoder)
 
     explicit Encoder(
-        int32_t serial_number, int hub_port, bool is_hub_port_device,
-        int channel,
+        const ChannelAddress &channel_address,
         std::function<void(int, int, double, int)> position_change_handler);
 
     ~Encoder();
@@ -82,8 +81,7 @@ class Encoder final
                                int index_triggered);
 
   private:
-    int32_t serial_number_;
-    int channel_;
+    ChannelAddress channel_address_;
     std::function<void(int, int, double, int)> position_change_handler_;
     PhidgetEncoderHandle encoder_handle_;
 

--- a/phidgets_api/include/phidgets_api/gyroscope.hpp
+++ b/phidgets_api/include/phidgets_api/gyroscope.hpp
@@ -44,7 +44,7 @@ class Gyroscope final
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Gyroscope)
 
     explicit Gyroscope(
-        int32_t serial_number, int hub_port, bool is_hub_port_device,
+        const ChannelAddress &channel_address,
         std::function<void(const double[3], double)> data_handler);
 
     ~Gyroscope();
@@ -61,7 +61,7 @@ class Gyroscope final
     void dataHandler(const double angular_rate[3], double timestamp) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetGyroscopeHandle gyro_handle_;
 

--- a/phidgets_api/include/phidgets_api/gyroscope.hpp
+++ b/phidgets_api/include/phidgets_api/gyroscope.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Gyroscope final
+class Gyroscope final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Gyroscope)
@@ -48,8 +48,6 @@ class Gyroscope final
         std::function<void(const double[3], double)> data_handler);
 
     ~Gyroscope();
-
-    int32_t getSerialNumber() const noexcept;
 
     void getAngularRate(double &x, double &y, double &z,
                         double &timestamp) const;
@@ -61,7 +59,6 @@ class Gyroscope final
     void dataHandler(const double angular_rate[3], double timestamp) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetGyroscopeHandle gyro_handle_;
 

--- a/phidgets_api/include/phidgets_api/ir.hpp
+++ b/phidgets_api/include/phidgets_api/ir.hpp
@@ -43,7 +43,7 @@ class IR final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(IR)
 
-    explicit IR(int32_t serial_number,
+    explicit IR(const ChannelAddress &channel_address,
                 std::function<void(const char *, uint32_t, int)> code_handler);
 
     ~IR();
@@ -53,7 +53,7 @@ class IR final
     void codeHandler(const char *code, uint32_t bit_count, int is_repeat) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(const char *, uint32_t, int)> code_handler_;
     PhidgetIRHandle ir_handle_;
 

--- a/phidgets_api/include/phidgets_api/ir.hpp
+++ b/phidgets_api/include/phidgets_api/ir.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class IR final
+class IR final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(IR)
@@ -48,12 +48,9 @@ class IR final
 
     ~IR();
 
-    int32_t getSerialNumber() const noexcept;
-
     void codeHandler(const char *code, uint32_t bit_count, int is_repeat) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(const char *, uint32_t, int)> code_handler_;
     PhidgetIRHandle ir_handle_;
 

--- a/phidgets_api/include/phidgets_api/magnetometer.hpp
+++ b/phidgets_api/include/phidgets_api/magnetometer.hpp
@@ -44,7 +44,7 @@ class Magnetometer final
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Magnetometer)
 
     explicit Magnetometer(
-        int32_t serial_number, int hub_port, bool is_hub_port_device,
+        const ChannelAddress &channel_address,
         std::function<void(const double[3], double)> data_handler);
 
     ~Magnetometer();
@@ -67,7 +67,7 @@ class Magnetometer final
     void dataHandler(const double magnetic_field[3], double timestamp) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetMagnetometerHandle mag_handle_;
 

--- a/phidgets_api/include/phidgets_api/magnetometer.hpp
+++ b/phidgets_api/include/phidgets_api/magnetometer.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Magnetometer final
+class Magnetometer final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Magnetometer)
@@ -48,8 +48,6 @@ class Magnetometer final
         std::function<void(const double[3], double)> data_handler);
 
     ~Magnetometer();
-
-    int32_t getSerialNumber() const noexcept;
 
     void setCompassCorrectionParameters(double cc_mag_field, double cc_offset0,
                                         double cc_offset1, double cc_offset2,
@@ -67,7 +65,6 @@ class Magnetometer final
     void dataHandler(const double magnetic_field[3], double timestamp) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(const double[3], double)> data_handler_;
     PhidgetMagnetometerHandle mag_handle_;
 

--- a/phidgets_api/include/phidgets_api/motor.hpp
+++ b/phidgets_api/include/phidgets_api/motor.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Motor final
+class Motor final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Motor)
@@ -48,8 +48,6 @@ class Motor final
                    std::function<void(int, double)> back_emf_change_handler);
 
     ~Motor();
-
-    int32_t getSerialNumber() const noexcept;
 
     double getDutyCycle() const;
     void setDutyCycle(double duty_cycle) const;
@@ -67,7 +65,6 @@ class Motor final
     void backEMFChangeHandler(double back_emf) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(int, double)> duty_cycle_change_handler_;
     std::function<void(int, double)> back_emf_change_handler_;
     PhidgetDCMotorHandle motor_handle_;

--- a/phidgets_api/include/phidgets_api/motor.hpp
+++ b/phidgets_api/include/phidgets_api/motor.hpp
@@ -43,8 +43,7 @@ class Motor final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Motor)
 
-    explicit Motor(int32_t serial_number, int hub_port, bool is_hub_port_device,
-                   int channel,
+    explicit Motor(const ChannelAddress &channel_address,
                    std::function<void(int, double)> duty_cycle_change_handler,
                    std::function<void(int, double)> back_emf_change_handler);
 
@@ -68,8 +67,7 @@ class Motor final
     void backEMFChangeHandler(double back_emf) const;
 
   private:
-    int32_t serial_number_;
-    int channel_;
+    ChannelAddress channel_address_;
     std::function<void(int, double)> duty_cycle_change_handler_;
     std::function<void(int, double)> back_emf_change_handler_;
     PhidgetDCMotorHandle motor_handle_;

--- a/phidgets_api/include/phidgets_api/phidget22.hpp
+++ b/phidgets_api/include/phidgets_api/phidget22.hpp
@@ -54,10 +54,17 @@ class Phidget22Error final : public std::exception
     std::string msg_;
 };
 
+struct ChannelAddress {
+    int32_t serial_number = PHIDGET_SERIALNUMBER_ANY;
+    int hub_port = PHIDGET_HUBPORT_ANY;
+    bool is_hub_port_device = false;
+    int channel = PHIDGET_CHANNEL_ANY;
+};
+
 namespace helpers {
 
-void openWaitForAttachment(PhidgetHandle handle, int32_t serial_number,
-                           int hub_port, bool is_hub_port_device, int channel);
+void openWaitForAttachment(PhidgetHandle handle,
+                           const ChannelAddress &channel_address);
 
 void closeAndDelete(PhidgetHandle *handle) noexcept;
 

--- a/phidgets_api/include/phidgets_api/phidget22.hpp
+++ b/phidgets_api/include/phidgets_api/phidget22.hpp
@@ -61,6 +61,19 @@ struct ChannelAddress {
     int channel = PHIDGET_CHANNEL_ANY;
 };
 
+class PhidgetChannel
+{
+  public:
+    explicit PhidgetChannel(const ChannelAddress &channel_address);
+
+    int32_t getSerialNumber() const noexcept;
+
+  protected:
+    ChannelAddress channel_address_;
+
+    void updateSerialNumber(PhidgetHandle handle);
+};
+
 namespace helpers {
 
 void openWaitForAttachment(PhidgetHandle handle,

--- a/phidgets_api/include/phidgets_api/spatial.hpp
+++ b/phidgets_api/include/phidgets_api/spatial.hpp
@@ -43,8 +43,7 @@ class Spatial final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Spatial)
 
-    explicit Spatial(int32_t serial_number, int hub_port,
-                     bool is_hub_port_device,
+    explicit Spatial(const ChannelAddress &channel_address,
                      std::function<void(const double[3], const double[3],
                                         const double[3], double)>
                          data_handler);
@@ -69,7 +68,7 @@ class Spatial final
                      const double magnetic_field[3], double timestamp) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(const double[3], const double[3], const double[3],
                        double)>
         data_handler_;

--- a/phidgets_api/include/phidgets_api/spatial.hpp
+++ b/phidgets_api/include/phidgets_api/spatial.hpp
@@ -38,7 +38,7 @@
 
 namespace phidgets {
 
-class Spatial final
+class Spatial final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Spatial)
@@ -49,8 +49,6 @@ class Spatial final
                          data_handler);
 
     ~Spatial();
-
-    int32_t getSerialNumber() const noexcept;
 
     void setCompassCorrectionParameters(double cc_mag_field, double cc_offset0,
                                         double cc_offset1, double cc_offset2,
@@ -68,7 +66,6 @@ class Spatial final
                      const double magnetic_field[3], double timestamp) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(const double[3], const double[3], const double[3],
                        double)>
         data_handler_;

--- a/phidgets_api/include/phidgets_api/temperature.hpp
+++ b/phidgets_api/include/phidgets_api/temperature.hpp
@@ -50,8 +50,7 @@ class Temperature final
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Temperature)
 
-    explicit Temperature(int32_t serial_number, int hub_port,
-                         bool is_hub_port_device,
+    explicit Temperature(const ChannelAddress &channel_address,
                          std::function<void(double)> temperature_handler);
 
     ~Temperature();
@@ -67,7 +66,7 @@ class Temperature final
     void temperatureChangeHandler(double temperature) const;
 
   private:
-    int32_t serial_number_;
+    ChannelAddress channel_address_;
     std::function<void(double)> temperature_handler_;
     PhidgetTemperatureSensorHandle temperature_handle_;
 

--- a/phidgets_api/include/phidgets_api/temperature.hpp
+++ b/phidgets_api/include/phidgets_api/temperature.hpp
@@ -45,7 +45,7 @@ enum class ThermocoupleType {
     T_TYPE = 4,
 };
 
-class Temperature final
+class Temperature final : PhidgetChannel
 {
   public:
     PHIDGET22_NO_COPY_NO_MOVE_NO_ASSIGN(Temperature)
@@ -54,8 +54,6 @@ class Temperature final
                          std::function<void(double)> temperature_handler);
 
     ~Temperature();
-
-    int32_t getSerialNumber() const noexcept;
 
     void setThermocoupleType(ThermocoupleType type);
 
@@ -66,7 +64,6 @@ class Temperature final
     void temperatureChangeHandler(double temperature) const;
 
   private:
-    ChannelAddress channel_address_;
     std::function<void(double)> temperature_handler_;
     PhidgetTemperatureSensorHandle temperature_handle_;
 

--- a/phidgets_api/src/accelerometer.cpp
+++ b/phidgets_api/src/accelerometer.cpp
@@ -40,9 +40,9 @@
 namespace phidgets {
 
 Accelerometer::Accelerometer(
-    int32_t serial_number, int hub_port, bool is_hub_port_device,
+    const ChannelAddress &channel_address,
     std::function<void(const double[3], double)> data_handler)
-    : serial_number_(serial_number), data_handler_(data_handler)
+    : channel_address_(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetAccelerometer_create(&accel_handle_);
     if (ret != EPHIDGET_OK)
@@ -51,8 +51,7 @@ Accelerometer::Accelerometer(
     }
 
     helpers::openWaitForAttachment(
-        reinterpret_cast<PhidgetHandle>(accel_handle_), serial_number, hub_port,
-        is_hub_port_device, 0);
+        reinterpret_cast<PhidgetHandle>(accel_handle_), channel_address_);
 
     ret = PhidgetAccelerometer_setOnAccelerationChangeHandler(
         accel_handle_, DataHandler, this);
@@ -62,10 +61,11 @@ Accelerometer::Accelerometer(
                              ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(accel_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(accel_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for acceleration",
@@ -82,7 +82,7 @@ Accelerometer::~Accelerometer()
 
 int32_t Accelerometer::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void Accelerometer::getAcceleration(double &x, double &y, double &z,

--- a/phidgets_api/src/accelerometer.cpp
+++ b/phidgets_api/src/accelerometer.cpp
@@ -42,7 +42,7 @@ namespace phidgets {
 Accelerometer::Accelerometer(
     const ChannelAddress &channel_address,
     std::function<void(const double[3], double)> data_handler)
-    : channel_address_(channel_address), data_handler_(data_handler)
+    : PhidgetChannel(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetAccelerometer_create(&accel_handle_);
     if (ret != EPHIDGET_OK)
@@ -61,28 +61,13 @@ Accelerometer::Accelerometer(
                              ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(accel_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for acceleration",
-                                 ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(accel_handle_));
 }
 
 Accelerometer::~Accelerometer()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(accel_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Accelerometer::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void Accelerometer::getAcceleration(double &x, double &y, double &z,

--- a/phidgets_api/src/analog_input.cpp
+++ b/phidgets_api/src/analog_input.cpp
@@ -41,7 +41,7 @@ namespace phidgets {
 
 AnalogInput::AnalogInput(const ChannelAddress &channel_address,
                          std::function<void(int, double)> input_handler)
-    : channel_address_(channel_address), input_handler_(input_handler)
+    : PhidgetChannel(channel_address), input_handler_(input_handler)
 {
     PhidgetReturnCode ret = PhidgetVoltageInput_create(&ai_handle_);
     if (ret != EPHIDGET_OK)
@@ -76,30 +76,13 @@ AnalogInput::AnalogInput(const ChannelAddress &channel_address,
             ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(ai_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error(
-                "Failed to get serial number for analog input channel " +
-                    std::to_string(channel_address_.channel),
-                ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(ai_handle_));
 }
 
 AnalogInput::~AnalogInput()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(ai_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t AnalogInput::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 double AnalogInput::getSensorValue() const

--- a/phidgets_api/src/digital_input.cpp
+++ b/phidgets_api/src/digital_input.cpp
@@ -39,7 +39,7 @@ namespace phidgets {
 
 DigitalInput::DigitalInput(const ChannelAddress &channel_address,
                            std::function<void(int, int)> input_handler)
-    : channel_address_(channel_address), input_handler_(input_handler)
+    : PhidgetChannel(channel_address), input_handler_(input_handler)
 {
     PhidgetReturnCode ret = PhidgetDigitalInput_create(&di_handle_);
     if (ret != EPHIDGET_OK)
@@ -63,30 +63,13 @@ DigitalInput::DigitalInput(const ChannelAddress &channel_address,
             ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(di_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error(
-                "Failed to get serial number for digital input channel " +
-                    std::to_string(channel_address_.channel),
-                ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(di_handle_));
 }
 
 DigitalInput::~DigitalInput()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(di_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t DigitalInput::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 bool DigitalInput::getInputValue() const

--- a/phidgets_api/src/digital_output.cpp
+++ b/phidgets_api/src/digital_output.cpp
@@ -37,9 +37,8 @@
 
 namespace phidgets {
 
-DigitalOutput::DigitalOutput(int32_t serial_number, int hub_port,
-                             bool is_hub_port_device, int channel)
-    : serial_number_(serial_number)
+DigitalOutput::DigitalOutput(const ChannelAddress &channel_address)
+    : channel_address_(channel_address)
 {
     PhidgetReturnCode ret;
 
@@ -48,23 +47,23 @@ DigitalOutput::DigitalOutput(int32_t serial_number, int hub_port,
     {
         throw Phidget22Error(
             "Failed to create DigitalOutput handle for channel " +
-                std::to_string(channel),
+                std::to_string(channel_address_.channel),
             ret);
     }
 
     helpers::openWaitForAttachment(reinterpret_cast<PhidgetHandle>(do_handle_),
-                                   serial_number, hub_port, is_hub_port_device,
-                                   channel);
+                                   channel_address_);
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(do_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(do_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error(
                 "Failed to get serial number for digital output channel " +
-                    std::to_string(channel),
+                    std::to_string(channel_address_.channel),
                 ret);
         }
     }
@@ -78,7 +77,7 @@ DigitalOutput::~DigitalOutput()
 
 int32_t DigitalOutput::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void DigitalOutput::setOutputState(bool state) const

--- a/phidgets_api/src/digital_output.cpp
+++ b/phidgets_api/src/digital_output.cpp
@@ -38,7 +38,7 @@
 namespace phidgets {
 
 DigitalOutput::DigitalOutput(const ChannelAddress &channel_address)
-    : channel_address_(channel_address)
+    : PhidgetChannel(channel_address)
 {
     PhidgetReturnCode ret;
 
@@ -54,30 +54,13 @@ DigitalOutput::DigitalOutput(const ChannelAddress &channel_address)
     helpers::openWaitForAttachment(reinterpret_cast<PhidgetHandle>(do_handle_),
                                    channel_address_);
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(do_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error(
-                "Failed to get serial number for digital output channel " +
-                    std::to_string(channel_address_.channel),
-                ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(do_handle_));
 }
 
 DigitalOutput::~DigitalOutput()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(do_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t DigitalOutput::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void DigitalOutput::setOutputState(bool state) const

--- a/phidgets_api/src/encoder.cpp
+++ b/phidgets_api/src/encoder.cpp
@@ -39,7 +39,7 @@ namespace phidgets {
 Encoder::Encoder(
     const ChannelAddress &channel_address,
     std::function<void(int, int, double, int)> position_change_handler)
-    : channel_address_(channel_address),
+    : PhidgetChannel(channel_address),
       position_change_handler_(position_change_handler)
 {
     // create the handle
@@ -62,30 +62,13 @@ Encoder::Encoder(
             ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(encoder_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error(
-                "Failed to get serial number for encoder channel " +
-                    std::to_string(channel_address_.channel),
-                ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(encoder_handle_));
 }
 
 Encoder::~Encoder()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(encoder_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Encoder::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 int64_t Encoder::getPosition() const

--- a/phidgets_api/src/gyroscope.cpp
+++ b/phidgets_api/src/gyroscope.cpp
@@ -41,7 +41,7 @@ namespace phidgets {
 
 Gyroscope::Gyroscope(const ChannelAddress &channel_address,
                      std::function<void(const double[3], double)> data_handler)
-    : channel_address_(channel_address), data_handler_(data_handler)
+    : PhidgetChannel(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetGyroscope_create(&gyro_handle_);
     if (ret != EPHIDGET_OK)
@@ -59,28 +59,13 @@ Gyroscope::Gyroscope(const ChannelAddress &channel_address,
         throw Phidget22Error("Failed to set Gyroscope update handler", ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(gyro_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for gyroscope",
-                                 ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(gyro_handle_));
 }
 
 Gyroscope::~Gyroscope()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(gyro_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Gyroscope::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void Gyroscope::zero() const

--- a/phidgets_api/src/gyroscope.cpp
+++ b/phidgets_api/src/gyroscope.cpp
@@ -39,10 +39,9 @@
 
 namespace phidgets {
 
-Gyroscope::Gyroscope(int32_t serial_number, int hub_port,
-                     bool is_hub_port_device,
+Gyroscope::Gyroscope(const ChannelAddress &channel_address,
                      std::function<void(const double[3], double)> data_handler)
-    : serial_number_(serial_number), data_handler_(data_handler)
+    : channel_address_(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetGyroscope_create(&gyro_handle_);
     if (ret != EPHIDGET_OK)
@@ -51,8 +50,7 @@ Gyroscope::Gyroscope(int32_t serial_number, int hub_port,
     }
 
     helpers::openWaitForAttachment(
-        reinterpret_cast<PhidgetHandle>(gyro_handle_), serial_number, hub_port,
-        is_hub_port_device, 0);
+        reinterpret_cast<PhidgetHandle>(gyro_handle_), channel_address_);
 
     ret = PhidgetGyroscope_setOnAngularRateUpdateHandler(gyro_handle_,
                                                          DataHandler, this);
@@ -61,10 +59,11 @@ Gyroscope::Gyroscope(int32_t serial_number, int hub_port,
         throw Phidget22Error("Failed to set Gyroscope update handler", ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(gyro_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(gyro_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for gyroscope",
@@ -81,7 +80,7 @@ Gyroscope::~Gyroscope()
 
 int32_t Gyroscope::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void Gyroscope::zero() const

--- a/phidgets_api/src/ir.cpp
+++ b/phidgets_api/src/ir.cpp
@@ -36,9 +36,10 @@
 
 namespace phidgets {
 
-IR::IR(int32_t serial_number,
-       std::function<void(const char *, uint32_t, int)> code_handler)
-    : serial_number_(serial_number), code_handler_(code_handler)
+IR::IR(const ChannelAddress &channel_address
+           std::function<void(const char *, uint32_t, int)>
+               code_handler)
+    : channel_address_(channel_address), code_handler_(code_handler)
 {
     // create the handle
     PhidgetReturnCode ret = PhidgetIR_create(&ir_handle_);
@@ -48,7 +49,7 @@ IR::IR(int32_t serial_number,
     }
 
     helpers::openWaitForAttachment(reinterpret_cast<PhidgetHandle>(ir_handle_),
-                                   serial_number, 0, false, 0);
+                                   channel_address);
 
     // register ir data callback
     ret = PhidgetIR_setOnCodeHandler(ir_handle_, CodeHandler, this);
@@ -57,10 +58,11 @@ IR::IR(int32_t serial_number,
         throw Phidget22Error("Failed to set code handler for ir", ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(ir_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(ir_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for IR", ret);
@@ -76,7 +78,7 @@ IR::~IR()
 
 int32_t IR::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void IR::codeHandler(const char *code, uint32_t bit_count, int is_repeat) const

--- a/phidgets_api/src/ir.cpp
+++ b/phidgets_api/src/ir.cpp
@@ -39,7 +39,7 @@ namespace phidgets {
 IR::IR(const ChannelAddress &channel_address
            std::function<void(const char *, uint32_t, int)>
                code_handler)
-    : channel_address_(channel_address), code_handler_(code_handler)
+    : PhidgetChannel(channel_address), code_handler_(code_handler)
 {
     // create the handle
     PhidgetReturnCode ret = PhidgetIR_create(&ir_handle_);
@@ -58,27 +58,13 @@ IR::IR(const ChannelAddress &channel_address
         throw Phidget22Error("Failed to set code handler for ir", ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(ir_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for IR", ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(ir_handle_));
 }
 
 IR::~IR()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(ir_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t IR::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void IR::codeHandler(const char *code, uint32_t bit_count, int is_repeat) const

--- a/phidgets_api/src/magnetometer.cpp
+++ b/phidgets_api/src/magnetometer.cpp
@@ -40,9 +40,9 @@
 namespace phidgets {
 
 Magnetometer::Magnetometer(
-    int32_t serial_number, int hub_port, bool is_hub_port_device,
+    const ChannelAddress &channel_address,
     std::function<void(const double[3], double)> data_handler)
-    : serial_number_(serial_number), data_handler_(data_handler)
+    : channel_address_(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetMagnetometer_create(&mag_handle_);
     if (ret != EPHIDGET_OK)
@@ -51,8 +51,7 @@ Magnetometer::Magnetometer(
     }
 
     helpers::openWaitForAttachment(reinterpret_cast<PhidgetHandle>(mag_handle_),
-                                   serial_number, hub_port, is_hub_port_device,
-                                   0);
+                                   channel_address);
 
     ret = PhidgetMagnetometer_setOnMagneticFieldChangeHandler(
         mag_handle_, DataHandler, this);
@@ -62,10 +61,11 @@ Magnetometer::Magnetometer(
                              ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(mag_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(mag_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for magnetometer",
@@ -82,7 +82,7 @@ Magnetometer::~Magnetometer()
 
 int32_t Magnetometer::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void Magnetometer::setCompassCorrectionParameters(

--- a/phidgets_api/src/magnetometer.cpp
+++ b/phidgets_api/src/magnetometer.cpp
@@ -42,7 +42,7 @@ namespace phidgets {
 Magnetometer::Magnetometer(
     const ChannelAddress &channel_address,
     std::function<void(const double[3], double)> data_handler)
-    : channel_address_(channel_address), data_handler_(data_handler)
+    : PhidgetChannel(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetMagnetometer_create(&mag_handle_);
     if (ret != EPHIDGET_OK)
@@ -61,28 +61,13 @@ Magnetometer::Magnetometer(
                              ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(mag_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for magnetometer",
-                                 ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(mag_handle_));
 }
 
 Magnetometer::~Magnetometer()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(mag_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Magnetometer::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void Magnetometer::setCompassCorrectionParameters(

--- a/phidgets_api/src/motor.cpp
+++ b/phidgets_api/src/motor.cpp
@@ -40,7 +40,7 @@ namespace phidgets {
 Motor::Motor(const ChannelAddress &channel_address,
              std::function<void(int, double)> duty_cycle_change_handler,
              std::function<void(int, double)> back_emf_change_handler)
-    : channel_address_(channel_address),
+    : PhidgetChannel(channel_address),
       duty_cycle_change_handler_(duty_cycle_change_handler),
       back_emf_change_handler_(back_emf_change_handler)
 {
@@ -89,30 +89,13 @@ Motor::Motor(const ChannelAddress &channel_address,
             ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(motor_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error(
-                "Failed to get serial number for motor channel " +
-                    std::to_string(channel_address_.channel),
-                ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(motor_handle_));
 }
 
 Motor::~Motor()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(motor_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Motor::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 double Motor::getDutyCycle() const

--- a/phidgets_api/src/motor.cpp
+++ b/phidgets_api/src/motor.cpp
@@ -37,12 +37,10 @@
 
 namespace phidgets {
 
-Motor::Motor(int32_t serial_number, int hub_port, bool is_hub_port_device,
-             int channel,
+Motor::Motor(const ChannelAddress &channel_address,
              std::function<void(int, double)> duty_cycle_change_handler,
              std::function<void(int, double)> back_emf_change_handler)
-    : serial_number_(serial_number),
-      channel_(channel),
+    : channel_address_(channel_address),
       duty_cycle_change_handler_(duty_cycle_change_handler),
       back_emf_change_handler_(back_emf_change_handler)
 {
@@ -50,13 +48,12 @@ Motor::Motor(int32_t serial_number, int hub_port, bool is_hub_port_device,
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to create Motor handle for channel " +
-                                 std::to_string(channel),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
 
     helpers::openWaitForAttachment(
-        reinterpret_cast<PhidgetHandle>(motor_handle_), serial_number, hub_port,
-        is_hub_port_device, channel);
+        reinterpret_cast<PhidgetHandle>(motor_handle_), channel_address_);
 
     ret = PhidgetDCMotor_setOnVelocityUpdateHandler(
         motor_handle_, DutyCycleChangeHandler, this);
@@ -64,7 +61,7 @@ Motor::Motor(int32_t serial_number, int hub_port, bool is_hub_port_device,
     {
         throw Phidget22Error(
             "Failed to set duty cycle update handler for Motor channel " +
-                std::to_string(channel),
+                std::to_string(channel_address_.channel),
             ret);
     }
 
@@ -81,26 +78,27 @@ Motor::Motor(int32_t serial_number, int hub_port, bool is_hub_port_device,
         {
             throw Phidget22Error(
                 "Failed to set back EMF update handler for Motor channel " +
-                    std::to_string(channel),
+                    std::to_string(channel_address_.channel),
                 ret);
         }
     } else
     {
         throw Phidget22Error(
             "Failed to set back EMF sensing state Motor channel " +
-                std::to_string(channel),
+                std::to_string(channel_address_.channel),
             ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(motor_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(motor_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error(
                 "Failed to get serial number for motor channel " +
-                    std::to_string(channel),
+                    std::to_string(channel_address_.channel),
                 ret);
         }
     }
@@ -114,7 +112,7 @@ Motor::~Motor()
 
 int32_t Motor::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 double Motor::getDutyCycle() const
@@ -125,7 +123,7 @@ double Motor::getDutyCycle() const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to get duty cycle for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
     return duty_cycle;
@@ -138,7 +136,7 @@ void Motor::setDutyCycle(double duty_cycle) const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set duty cycle for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
 }
@@ -151,7 +149,7 @@ double Motor::getAcceleration() const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to get acceleration for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
     return accel;
@@ -164,7 +162,7 @@ void Motor::setAcceleration(double acceleration) const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set acceleration for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
 }
@@ -186,7 +184,7 @@ double Motor::getBackEMF() const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to get back EMF for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
     return backemf;
@@ -199,7 +197,7 @@ void Motor::setDataInterval(uint32_t data_interval_ms) const
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set data interval for Motor channel " +
-                                 std::to_string(channel_),
+                                 std::to_string(channel_address_.channel),
                              ret);
     }
 }
@@ -213,7 +211,7 @@ double Motor::getBraking() const
     {
         throw Phidget22Error(
             "Failed to get braking strength for Motor channel " +
-                std::to_string(channel_),
+                std::to_string(channel_address_.channel),
             ret);
     }
     return braking;
@@ -227,19 +225,19 @@ void Motor::setBraking(double braking) const
     {
         throw Phidget22Error(
             "Failed to set braking strength for Motor channel " +
-                std::to_string(channel_),
+                std::to_string(channel_address_.channel),
             ret);
     }
 }
 
 void Motor::dutyCycleChangeHandler(double duty_cycle) const
 {
-    duty_cycle_change_handler_(channel_, duty_cycle);
+    duty_cycle_change_handler_(channel_address_.channel, duty_cycle);
 }
 
 void Motor::backEMFChangeHandler(double back_emf) const
 {
-    back_emf_change_handler_(channel_, back_emf);
+    back_emf_change_handler_(channel_address_.channel, back_emf);
 }
 
 void Motor::DutyCycleChangeHandler(PhidgetDCMotorHandle /* motor_handle */,

--- a/phidgets_api/src/phidget22.cpp
+++ b/phidgets_api/src/phidget22.cpp
@@ -52,6 +52,29 @@ const char *Phidget22Error::what() const noexcept
     return msg_.c_str();
 }
 
+PhidgetChannel::PhidgetChannel(const ChannelAddress &channel_address)
+    : channel_address_(channel_address)
+{
+}
+
+int32_t PhidgetChannel::getSerialNumber() const noexcept
+{
+    return channel_address_.serial_number;
+}
+
+PhidgetChannel::updateSerialNumber(PhidgetHandle handle)
+{
+    if (channel_address_.serial_number == -1)
+    {
+        ret = Phidget_getDeviceSerialNumber(handle,
+                                            &channel_address_.serial_number);
+        if (ret != EPHIDGET_OK)
+        {
+            throw Phidget22Error("Failed to get serial number", ret);
+        }
+    }
+}
+
 namespace helpers {
 
 void openWaitForAttachment(PhidgetHandle handle,

--- a/phidgets_api/src/phidget22.cpp
+++ b/phidgets_api/src/phidget22.cpp
@@ -54,30 +54,31 @@ const char *Phidget22Error::what() const noexcept
 
 namespace helpers {
 
-void openWaitForAttachment(PhidgetHandle handle, int32_t serial_number,
-                           int hub_port, bool is_hub_port_device, int channel)
+void openWaitForAttachment(PhidgetHandle handle,
+                           const ChannelAddress &channel_address)
 {
     PhidgetReturnCode ret;
 
-    ret = Phidget_setDeviceSerialNumber(handle, serial_number);
+    ret = Phidget_setDeviceSerialNumber(handle, channel_address.serial_number);
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set device serial number", ret);
     }
 
-    ret = Phidget_setHubPort(handle, hub_port);
+    ret = Phidget_setHubPort(handle, channel_address.hub_port);
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set device hub port", ret);
     }
 
-    ret = Phidget_setIsHubPortDevice(handle, is_hub_port_device);
+    ret =
+        Phidget_setIsHubPortDevice(handle, channel_address.is_hub_port_device);
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set device is hub port device", ret);
     }
 
-    ret = Phidget_setChannel(handle, channel);
+    ret = Phidget_setChannel(handle, channel_address.channel);
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set device channel", ret);

--- a/phidgets_api/src/spatial.cpp
+++ b/phidgets_api/src/spatial.cpp
@@ -39,11 +39,11 @@
 
 namespace phidgets {
 
-Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
+Spatial::Spatial(const ChannelAddress &channel_address,
                  std::function<void(const double[3], const double[3],
                                     const double[3], double)>
                      data_handler)
-    : serial_number_(serial_number), data_handler_(data_handler)
+    : channel_address_(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetSpatial_create(&spatial_handle_);
     if (ret != EPHIDGET_OK)
@@ -52,8 +52,7 @@ Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
     }
 
     helpers::openWaitForAttachment(
-        reinterpret_cast<PhidgetHandle>(spatial_handle_), serial_number,
-        hub_port, is_hub_port_device, 0);
+        reinterpret_cast<PhidgetHandle>(spatial_handle_), channel_address);
 
     ret = PhidgetSpatial_setOnSpatialDataHandler(spatial_handle_, DataHandler,
                                                  this);
@@ -62,10 +61,11 @@ Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
         throw Phidget22Error("Failed to set change handler for Spatial", ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(spatial_handle_), &serial_number_);
+            reinterpret_cast<PhidgetHandle>(spatial_handle_),
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for spatial",
@@ -82,7 +82,7 @@ Spatial::~Spatial()
 
 int32_t Spatial::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void Spatial::zero() const

--- a/phidgets_api/src/spatial.cpp
+++ b/phidgets_api/src/spatial.cpp
@@ -43,7 +43,7 @@ Spatial::Spatial(const ChannelAddress &channel_address,
                  std::function<void(const double[3], const double[3],
                                     const double[3], double)>
                      data_handler)
-    : channel_address_(channel_address), data_handler_(data_handler)
+    : PhidgetChannel(channel_address), data_handler_(data_handler)
 {
     PhidgetReturnCode ret = PhidgetSpatial_create(&spatial_handle_);
     if (ret != EPHIDGET_OK)
@@ -61,28 +61,13 @@ Spatial::Spatial(const ChannelAddress &channel_address,
         throw Phidget22Error("Failed to set change handler for Spatial", ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(spatial_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for spatial",
-                                 ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(spatial_handle_));
 }
 
 Spatial::~Spatial()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(spatial_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Spatial::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void Spatial::zero() const

--- a/phidgets_api/src/temperature.cpp
+++ b/phidgets_api/src/temperature.cpp
@@ -39,8 +39,7 @@ namespace phidgets {
 
 Temperature::Temperature(const ChannelAddress &channel_address,
                          std::function<void(double)> temperature_handler)
-    : channel_address_(channel_address),
-      temperature_handler_(temperature_handler)
+    : PhidgetChannel(channel_address), temperature_handler_(temperature_handler)
 {
     PhidgetReturnCode ret =
         PhidgetTemperatureSensor_create(&temperature_handle_);
@@ -60,28 +59,13 @@ Temperature::Temperature(const ChannelAddress &channel_address,
                              ret);
     }
 
-    if (channel_address_.serial_number == -1)
-    {
-        ret = Phidget_getDeviceSerialNumber(
-            reinterpret_cast<PhidgetHandle>(temperature_handle_),
-            &channel_address_.serial_number);
-        if (ret != EPHIDGET_OK)
-        {
-            throw Phidget22Error("Failed to get serial number for temperature",
-                                 ret);
-        }
-    }
+    updateSerialNumber(reinterpret_cast<PhidgetHandle>(temperature_handle_));
 }
 
 Temperature::~Temperature()
 {
     PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(temperature_handle_);
     helpers::closeAndDelete(&handle);
-}
-
-int32_t Temperature::getSerialNumber() const noexcept
-{
-    return channel_address_.serial_number;
 }
 
 void Temperature::setThermocoupleType(ThermocoupleType type)

--- a/phidgets_api/src/temperature.cpp
+++ b/phidgets_api/src/temperature.cpp
@@ -37,10 +37,10 @@
 
 namespace phidgets {
 
-Temperature::Temperature(int32_t serial_number, int hub_port,
-                         bool is_hub_port_device,
+Temperature::Temperature(const ChannelAddress &channel_address,
                          std::function<void(double)> temperature_handler)
-    : serial_number_(serial_number), temperature_handler_(temperature_handler)
+    : channel_address_(channel_address),
+      temperature_handler_(temperature_handler)
 {
     PhidgetReturnCode ret =
         PhidgetTemperatureSensor_create(&temperature_handle_);
@@ -50,8 +50,7 @@ Temperature::Temperature(int32_t serial_number, int hub_port,
     }
 
     helpers::openWaitForAttachment(
-        reinterpret_cast<PhidgetHandle>(temperature_handle_), serial_number,
-        hub_port, is_hub_port_device, 0);
+        reinterpret_cast<PhidgetHandle>(temperature_handle_), channel_address);
 
     ret = PhidgetTemperatureSensor_setOnTemperatureChangeHandler(
         temperature_handle_, TemperatureChangeHandler, this);
@@ -61,11 +60,11 @@ Temperature::Temperature(int32_t serial_number, int hub_port,
                              ret);
     }
 
-    if (serial_number_ == -1)
+    if (channel_address_.serial_number == -1)
     {
         ret = Phidget_getDeviceSerialNumber(
             reinterpret_cast<PhidgetHandle>(temperature_handle_),
-            &serial_number_);
+            &channel_address_.serial_number);
         if (ret != EPHIDGET_OK)
         {
             throw Phidget22Error("Failed to get serial number for temperature",
@@ -82,7 +81,7 @@ Temperature::~Temperature()
 
 int32_t Temperature::getSerialNumber() const noexcept
 {
-    return serial_number_;
+    return channel_address_.serial_number;
 }
 
 void Temperature::setThermocoupleType(ThermocoupleType type)


### PR DESCRIPTION
What do you think of using a ChannelAddress struct when opening channels rather than individual parameters?

I realize this pull request breaks every package, but it would add flexibility for potentially adding more ChannelAddress members in the future and for perhaps using a vector of ChannelAddress when creating nodes. Right now, nodes are limited to a single port. If we pass a vector of ChannelAddress, then a node could access a whole set of ports.

I would need to go back and modify every package before you could accept this pull request. I am just throwing this change out for discussion.