### PR TITLE
Add developing documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,14 @@ To set up the udev rules for the Phidgets USB devices, run the following command
     sudo udevadm control --reload-rules
 
 Afterwards, disconnect the USB cable and plug it in again (or run `sudo udevadm trigger`).
+
+Developing
+----------
+
+To check formatting after modifying source code:
+
+    python3 clang-check-style.py
+
+To reformat source code:
+
+    find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-6.0 -i -style=file $1


### PR DESCRIPTION
I am not sure this documentation is appropriate to add to the README. If not, feel free to reject this pull request. I find it useful cat the README to remind myself of the reformatting commands before committing. Perhaps this documentation could go somewhere else or should just be remove entirely.