### PR TITLE
Fixes pointed out by clang-tidy

### DIFF
--- a/phidgets_accelerometer/include/phidgets_accelerometer/accelerometer_ros_i.hpp
+++ b/phidgets_accelerometer/include/phidgets_accelerometer/accelerometer_ros_i.hpp
@@ -51,11 +51,11 @@ class AccelerometerRosI final : public rclcpp::Node
   private:
     std::unique_ptr<Accelerometer> accelerometer_;
     std::string frame_id_;
-    double linear_acceleration_variance_;
+    double linear_acceleration_variance_{0.0};
     std::mutex accel_mutex_;
-    double last_accel_x_;
-    double last_accel_y_;
-    double last_accel_z_;
+    double last_accel_x_{0.0};
+    double last_accel_y_{0.0};
+    double last_accel_z_{0.0};
 
     rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr accelerometer_pub_;
     void timerCallback();

--- a/phidgets_accelerometer/src/accelerometer_ros_i.cpp
+++ b/phidgets_accelerometer/src/accelerometer_ros_i.cpp
@@ -44,7 +44,7 @@ namespace phidgets {
 AccelerometerRosI::AccelerometerRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_accelerometer_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Accelerometer");
 

--- a/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
+++ b/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
@@ -45,7 +45,7 @@ namespace phidgets {
 AnalogInputsRosI::AnalogInputsRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_analog_inputs_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets AnalogInputs");
 

--- a/phidgets_api/include/phidgets_api/accelerometer.hpp
+++ b/phidgets_api/include/phidgets_api/accelerometer.hpp
@@ -61,7 +61,7 @@ class Accelerometer final
   private:
     int32_t serial_number_;
     std::function<void(const double[3], double)> data_handler_;
-    PhidgetAccelerometerHandle accel_handle_;
+    PhidgetAccelerometerHandle accel_handle_{nullptr};
 
     static void DataHandler(PhidgetAccelerometerHandle input_handle, void *ctx,
                             const double acceleration[3], double timestamp);

--- a/phidgets_api/include/phidgets_api/accelerometer.hpp
+++ b/phidgets_api/include/phidgets_api/accelerometer.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_ACCELEROMETER_H
 #define PHIDGETS_API_ACCELEROMETER_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/analog_input.hpp
+++ b/phidgets_api/include/phidgets_api/analog_input.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_ANALOG_INPUT_H
 #define PHIDGETS_API_ANALOG_INPUT_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/analog_input.hpp
+++ b/phidgets_api/include/phidgets_api/analog_input.hpp
@@ -61,7 +61,7 @@ class AnalogInput final
     int32_t serial_number_;
     int channel_;
     std::function<void(int, double)> input_handler_;
-    PhidgetVoltageInputHandle ai_handle_;
+    PhidgetVoltageInputHandle ai_handle_{nullptr};
 
     static void VoltageChangeHandler(PhidgetVoltageInputHandle input_handle,
                                      void *ctx, double sensorValue);

--- a/phidgets_api/include/phidgets_api/analog_inputs.hpp
+++ b/phidgets_api/include/phidgets_api/analog_inputs.hpp
@@ -59,7 +59,7 @@ class AnalogInputs final
     void setDataInterval(int index, uint32_t data_interval_ms) const;
 
   private:
-    uint32_t input_count_;
+    uint32_t input_count_{0};
     std::vector<std::unique_ptr<AnalogInput>> ais_;
 };
 

--- a/phidgets_api/include/phidgets_api/digital_input.hpp
+++ b/phidgets_api/include/phidgets_api/digital_input.hpp
@@ -59,7 +59,7 @@ class DigitalInput
     int32_t serial_number_;
     int channel_;
     std::function<void(int, int)> input_handler_;
-    PhidgetDigitalInputHandle di_handle_;
+    PhidgetDigitalInputHandle di_handle_{nullptr};
 
     static void StateChangeHandler(PhidgetDigitalInputHandle input_handle,
                                    void *ctx, int state);

--- a/phidgets_api/include/phidgets_api/digital_input.hpp
+++ b/phidgets_api/include/phidgets_api/digital_input.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_DIGITAL_INPUT_H
 #define PHIDGETS_API_DIGITAL_INPUT_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/digital_inputs.hpp
+++ b/phidgets_api/include/phidgets_api/digital_inputs.hpp
@@ -57,7 +57,7 @@ class DigitalInputs
     bool getInputValue(int index) const;
 
   private:
-    uint32_t input_count_;
+    uint32_t input_count_{0};
     std::vector<std::unique_ptr<DigitalInput>> dis_;
 };
 

--- a/phidgets_api/include/phidgets_api/digital_output.hpp
+++ b/phidgets_api/include/phidgets_api/digital_output.hpp
@@ -30,6 +30,8 @@
 #ifndef PHIDGETS_API_DIGITAL_OUTPUT_H
 #define PHIDGETS_API_DIGITAL_OUTPUT_H
 
+#include <cstddef>
+
 #include <libphidget22/phidget22.h>
 
 #include "phidgets_api/phidget22.hpp"

--- a/phidgets_api/include/phidgets_api/digital_output.hpp
+++ b/phidgets_api/include/phidgets_api/digital_output.hpp
@@ -52,7 +52,7 @@ class DigitalOutput final
 
   private:
     int32_t serial_number_;
-    PhidgetDigitalOutputHandle do_handle_;
+    PhidgetDigitalOutputHandle do_handle_{nullptr};
 };
 
 }  // namespace phidgets

--- a/phidgets_api/include/phidgets_api/digital_outputs.hpp
+++ b/phidgets_api/include/phidgets_api/digital_outputs.hpp
@@ -55,7 +55,7 @@ class DigitalOutputs final
     void setOutputState(int index, bool state) const;
 
   private:
-    uint32_t output_count_;
+    uint32_t output_count_{0};
     std::vector<std::unique_ptr<DigitalOutput>> dos_;
 };
 

--- a/phidgets_api/include/phidgets_api/encoder.hpp
+++ b/phidgets_api/include/phidgets_api/encoder.hpp
@@ -85,7 +85,7 @@ class Encoder final
     int32_t serial_number_;
     int channel_;
     std::function<void(int, int, double, int)> position_change_handler_;
-    PhidgetEncoderHandle encoder_handle_;
+    PhidgetEncoderHandle encoder_handle_{nullptr};
 
     static void PositionChangeHandler(PhidgetEncoderHandle phid, void *ctx,
                                       int position_change, double time_change,

--- a/phidgets_api/include/phidgets_api/encoder.hpp
+++ b/phidgets_api/include/phidgets_api/encoder.hpp
@@ -89,7 +89,7 @@ class Encoder final
     PhidgetEncoderHandle encoder_handle_{nullptr};
 
     static void PositionChangeHandler(PhidgetEncoderHandle phid, void *ctx,
-                                      int position_change, double time_change,
+                                      int position_change, double time,
                                       int index_triggered);
 };
 

--- a/phidgets_api/include/phidgets_api/encoder.hpp
+++ b/phidgets_api/include/phidgets_api/encoder.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_ENCODER_H
 #define PHIDGETS_API_ENCODER_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/encoders.hpp
+++ b/phidgets_api/include/phidgets_api/encoders.hpp
@@ -85,7 +85,7 @@ class Encoders final
     void setEnabled(int index, bool enabled) const;
 
   private:
-    uint32_t encoder_count_;
+    uint32_t encoder_count_{0};
     std::vector<std::unique_ptr<Encoder>> encs_;
 };
 

--- a/phidgets_api/include/phidgets_api/gyroscope.hpp
+++ b/phidgets_api/include/phidgets_api/gyroscope.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_GYROSCOPE_H
 #define PHIDGETS_API_GYROSCOPE_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/gyroscope.hpp
+++ b/phidgets_api/include/phidgets_api/gyroscope.hpp
@@ -63,7 +63,7 @@ class Gyroscope final
   private:
     int32_t serial_number_;
     std::function<void(const double[3], double)> data_handler_;
-    PhidgetGyroscopeHandle gyro_handle_;
+    PhidgetGyroscopeHandle gyro_handle_{nullptr};
 
     static void DataHandler(PhidgetGyroscopeHandle input_handle, void *ctx,
                             const double angular_rate[3], double timestamp);

--- a/phidgets_api/include/phidgets_api/ir.hpp
+++ b/phidgets_api/include/phidgets_api/ir.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_IR_H
 #define PHIDGETS_API_IR_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/ir.hpp
+++ b/phidgets_api/include/phidgets_api/ir.hpp
@@ -55,7 +55,7 @@ class IR final
   private:
     int32_t serial_number_;
     std::function<void(const char *, uint32_t, int)> code_handler_;
-    PhidgetIRHandle ir_handle_;
+    PhidgetIRHandle ir_handle_{nullptr};
 
     static void CodeHandler(PhidgetIRHandle ir, void *ctx, const char *code,
                             uint32_t bit_count, int is_repeat);

--- a/phidgets_api/include/phidgets_api/magnetometer.hpp
+++ b/phidgets_api/include/phidgets_api/magnetometer.hpp
@@ -69,7 +69,7 @@ class Magnetometer final
   private:
     int32_t serial_number_;
     std::function<void(const double[3], double)> data_handler_;
-    PhidgetMagnetometerHandle mag_handle_;
+    PhidgetMagnetometerHandle mag_handle_{nullptr};
 
     static void DataHandler(PhidgetMagnetometerHandle input_handle, void *ctx,
                             const double magnetic_field[3], double timestamp);

--- a/phidgets_api/include/phidgets_api/magnetometer.hpp
+++ b/phidgets_api/include/phidgets_api/magnetometer.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_MAGNETOMETER_H
 #define PHIDGETS_API_MAGNETOMETER_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/motor.hpp
+++ b/phidgets_api/include/phidgets_api/motor.hpp
@@ -72,7 +72,7 @@ class Motor final
     int channel_;
     std::function<void(int, double)> duty_cycle_change_handler_;
     std::function<void(int, double)> back_emf_change_handler_;
-    PhidgetDCMotorHandle motor_handle_;
+    PhidgetDCMotorHandle motor_handle_{nullptr};
     bool back_emf_sensing_supported_;
 
     static void DutyCycleChangeHandler(PhidgetDCMotorHandle motor_handle,

--- a/phidgets_api/include/phidgets_api/motor.hpp
+++ b/phidgets_api/include/phidgets_api/motor.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_MOTOR_H
 #define PHIDGETS_API_MOTOR_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/motors.hpp
+++ b/phidgets_api/include/phidgets_api/motors.hpp
@@ -66,7 +66,7 @@ class Motors final
     void setBraking(int index, double braking) const;
 
   private:
-    uint32_t motor_count_;
+    uint32_t motor_count_{0};
     std::vector<std::unique_ptr<Motor>> motors_;
 };
 

--- a/phidgets_api/include/phidgets_api/phidget22.hpp
+++ b/phidgets_api/include/phidgets_api/phidget22.hpp
@@ -48,7 +48,7 @@ class Phidget22Error final : public std::exception
   public:
     explicit Phidget22Error(const std::string &msg, PhidgetReturnCode code);
 
-    const char *what() const noexcept;
+    const char *what() const noexcept override;
 
   private:
     std::string msg_;

--- a/phidgets_api/include/phidgets_api/spatial.hpp
+++ b/phidgets_api/include/phidgets_api/spatial.hpp
@@ -73,7 +73,7 @@ class Spatial final
     std::function<void(const double[3], const double[3], const double[3],
                        double)>
         data_handler_;
-    PhidgetSpatialHandle spatial_handle_;
+    PhidgetSpatialHandle spatial_handle_{nullptr};
 
     static void DataHandler(PhidgetSpatialHandle input_handle, void *ctx,
                             const double acceleration[3],

--- a/phidgets_api/include/phidgets_api/spatial.hpp
+++ b/phidgets_api/include/phidgets_api/spatial.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_SPATIAL_H
 #define PHIDGETS_API_SPATIAL_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/temperature.hpp
+++ b/phidgets_api/include/phidgets_api/temperature.hpp
@@ -30,6 +30,7 @@
 #ifndef PHIDGETS_API_TEMPERATURE_H
 #define PHIDGETS_API_TEMPERATURE_H
 
+#include <cstddef>
 #include <functional>
 
 #include <libphidget22/phidget22.h>

--- a/phidgets_api/include/phidgets_api/temperature.hpp
+++ b/phidgets_api/include/phidgets_api/temperature.hpp
@@ -69,7 +69,7 @@ class Temperature final
   private:
     int32_t serial_number_;
     std::function<void(double)> temperature_handler_;
-    PhidgetTemperatureSensorHandle temperature_handle_;
+    PhidgetTemperatureSensorHandle temperature_handle_{nullptr};
 
     static void TemperatureChangeHandler(
         PhidgetTemperatureSensorHandle temperature_handle, void *ctx,

--- a/phidgets_api/src/accelerometer.cpp
+++ b/phidgets_api/src/accelerometer.cpp
@@ -130,7 +130,8 @@ void Accelerometer::DataHandler(PhidgetAccelerometerHandle /* input_handle */,
                                 void *ctx, const double acceleration[3],
                                 double timestamp)
 {
-    ((Accelerometer *)ctx)->dataHandler(acceleration, timestamp);
+    (reinterpret_cast<Accelerometer *>(ctx))
+        ->dataHandler(acceleration, timestamp);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/analog_input.cpp
+++ b/phidgets_api/src/analog_input.cpp
@@ -136,7 +136,7 @@ void AnalogInput::voltageChangeHandler(double sensorValue) const
 void AnalogInput::VoltageChangeHandler(
     PhidgetVoltageInputHandle /* input_handle */, void *ctx, double sensorValue)
 {
-    ((AnalogInput *)ctx)->voltageChangeHandler(sensorValue);
+    (reinterpret_cast<AnalogInput *>(ctx))->voltageChangeHandler(sensorValue);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/digital_input.cpp
+++ b/phidgets_api/src/digital_input.cpp
@@ -112,7 +112,7 @@ void DigitalInput::stateChangeHandler(int state) const
 void DigitalInput::StateChangeHandler(
     PhidgetDigitalInputHandle /* input_handle */, void *ctx, int state)
 {
-    ((DigitalInput *)ctx)->stateChangeHandler(state);
+    (reinterpret_cast<DigitalInput *>(ctx))->stateChangeHandler(state);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/encoder.cpp
+++ b/phidgets_api/src/encoder.cpp
@@ -169,7 +169,7 @@ void Encoder::PositionChangeHandler(PhidgetEncoderHandle /* phid */, void *ctx,
                                     int position_change, double time,
                                     int index_triggered)
 {
-    ((Encoder *)ctx)
+    (reinterpret_cast<Encoder *>(ctx))
         ->positionChangeHandler(position_change, time, index_triggered);
 }
 

--- a/phidgets_api/src/gyroscope.cpp
+++ b/phidgets_api/src/gyroscope.cpp
@@ -138,7 +138,7 @@ void Gyroscope::DataHandler(PhidgetGyroscopeHandle /* input_handle */,
                             void *ctx, const double angular_rate[3],
                             double timestamp)
 {
-    ((Gyroscope *)ctx)->dataHandler(angular_rate, timestamp);
+    (reinterpret_cast<Gyroscope *>(ctx))->dataHandler(angular_rate, timestamp);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/ir.cpp
+++ b/phidgets_api/src/ir.cpp
@@ -87,7 +87,7 @@ void IR::codeHandler(const char *code, uint32_t bit_count, int is_repeat) const
 void IR::CodeHandler(PhidgetIRHandle /* ir */, void *ctx, const char *code,
                      uint32_t bit_count, int is_repeat)
 {
-    ((IR *)ctx)->codeHandler(code, bit_count, is_repeat);
+    (reinterpret_cast<IR *>(ctx))->codeHandler(code, bit_count, is_repeat);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/magnetometer.cpp
+++ b/phidgets_api/src/magnetometer.cpp
@@ -146,7 +146,8 @@ void Magnetometer::DataHandler(PhidgetMagnetometerHandle /* input_handle */,
                                void *ctx, const double magnetic_field[3],
                                double timestamp)
 {
-    ((Magnetometer *)ctx)->dataHandler(magnetic_field, timestamp);
+    (reinterpret_cast<Magnetometer *>(ctx))
+        ->dataHandler(magnetic_field, timestamp);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/motor.cpp
+++ b/phidgets_api/src/motor.cpp
@@ -245,13 +245,13 @@ void Motor::backEMFChangeHandler(double back_emf) const
 void Motor::DutyCycleChangeHandler(PhidgetDCMotorHandle /* motor_handle */,
                                    void *ctx, double duty_cycle)
 {
-    ((Motor *)ctx)->dutyCycleChangeHandler(duty_cycle);
+    (reinterpret_cast<Motor *>(ctx))->dutyCycleChangeHandler(duty_cycle);
 }
 
 void Motor::BackEMFChangeHandler(PhidgetDCMotorHandle /* motor_handle */,
                                  void *ctx, double back_emf)
 {
-    ((Motor *)ctx)->backEMFChangeHandler(back_emf);
+    (reinterpret_cast<Motor *>(ctx))->backEMFChangeHandler(back_emf);
 }
 
 }  // namespace phidgets

--- a/phidgets_api/src/phidget22.cpp
+++ b/phidgets_api/src/phidget22.cpp
@@ -34,7 +34,6 @@
 namespace phidgets {
 
 Phidget22Error::Phidget22Error(const std::string &msg, PhidgetReturnCode code)
-    : std::exception()
 {
     const char *error_ptr;
     PhidgetReturnCode ret = Phidget_getErrorDescription(code, &error_ptr);

--- a/phidgets_api/src/spatial.cpp
+++ b/phidgets_api/src/spatial.cpp
@@ -133,7 +133,7 @@ void Spatial::DataHandler(PhidgetSpatialHandle /* input_handle */, void *ctx,
                           const double angular_rate[3],
                           const double magnetic_field[3], double timestamp)
 {
-    ((Spatial *)ctx)
+    (reinterpret_cast<Spatial *>(ctx))
         ->dataHandler(acceleration, angular_rate, magnetic_field, timestamp);
 }
 

--- a/phidgets_api/src/temperature.cpp
+++ b/phidgets_api/src/temperature.cpp
@@ -128,7 +128,8 @@ void Temperature::TemperatureChangeHandler(
     PhidgetTemperatureSensorHandle /* temperature_handle */, void *ctx,
     double temperature)
 {
-    ((Temperature *)ctx)->temperatureChangeHandler(temperature);
+    (reinterpret_cast<Temperature *>(ctx))
+        ->temperatureChangeHandler(temperature);
 }
 
 }  // namespace phidgets

--- a/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
+++ b/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
@@ -45,7 +45,7 @@ namespace phidgets {
 DigitalInputsRosI::DigitalInputsRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_digital_inputs_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets DigitalInputs");
 

--- a/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
+++ b/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
@@ -44,7 +44,7 @@ namespace phidgets {
 DigitalOutputsRosI::DigitalOutputsRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_digital_outputs_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Digital Outputs");
 

--- a/phidgets_gyroscope/include/phidgets_gyroscope/gyroscope_ros_i.hpp
+++ b/phidgets_gyroscope/include/phidgets_gyroscope/gyroscope_ros_i.hpp
@@ -51,11 +51,11 @@ class GyroscopeRosI final : public rclcpp::Node
   private:
     std::unique_ptr<Gyroscope> gyroscope_;
     std::string frame_id_;
-    double angular_velocity_variance_;
+    double angular_velocity_variance_{0.0};
     std::mutex gyro_mutex_;
-    double last_gyro_x_;
-    double last_gyro_y_;
-    double last_gyro_z_;
+    double last_gyro_x_{0.0};
+    double last_gyro_y_{0.0};
+    double last_gyro_z_{0.0};
 
     rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr cal_publisher_;
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr cal_srv_;

--- a/phidgets_gyroscope/src/gyroscope_ros_i.cpp
+++ b/phidgets_gyroscope/src/gyroscope_ros_i.cpp
@@ -48,7 +48,7 @@ namespace phidgets {
 GyroscopeRosI::GyroscopeRosI(const rclcpp::NodeOptions &options)
     : rclcpp::Node("phidgets_gyroscope_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Gyroscope");
 

--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -46,7 +46,7 @@ namespace phidgets {
 HighSpeedEncoderRosI::HighSpeedEncoderRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_high_speed_encoder_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Encoders");
 

--- a/phidgets_magnetometer/include/phidgets_magnetometer/magnetometer_ros_i.hpp
+++ b/phidgets_magnetometer/include/phidgets_magnetometer/magnetometer_ros_i.hpp
@@ -49,11 +49,11 @@ class MagnetometerRosI final : public rclcpp::Node
   private:
     std::unique_ptr<Magnetometer> magnetometer_;
     std::string frame_id_;
-    double magnetic_field_variance_;
+    double magnetic_field_variance_{0.0};
     std::mutex mag_mutex_;
-    double last_mag_x_;
-    double last_mag_y_;
-    double last_mag_z_;
+    double last_mag_x_{0.0};
+    double last_mag_y_{0.0};
+    double last_mag_z_{0.0};
 
     rclcpp::Publisher<sensor_msgs::msg::MagneticField>::SharedPtr
         magnetometer_pub_;

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -134,7 +134,7 @@ MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
         cc_T4 = this->get_parameter("cc_t4").get_value<double>();
         cc_T5 = this->get_parameter("cc_t5").get_value<double>();
         has_compass_params = true;
-    } catch (const rclcpp::exceptions::ParameterNotDeclaredException)
+    } catch (const rclcpp::exceptions::ParameterNotDeclaredException&)
     {
     }
 

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -43,7 +43,7 @@ namespace phidgets {
 MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_magnetometer_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Magnetometer");
 

--- a/phidgets_motors/include/phidgets_motors/motors_ros_i.hpp
+++ b/phidgets_motors/include/phidgets_motors/motors_ros_i.hpp
@@ -35,8 +35,8 @@
 #include <string>
 #include <vector>
 
-#include <std_msgs/msg/float64.h>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64.hpp>
 
 #include "phidgets_api/motors.hpp"
 

--- a/phidgets_motors/src/motors_ros_i.cpp
+++ b/phidgets_motors/src/motors_ros_i.cpp
@@ -45,7 +45,7 @@ namespace phidgets {
 MotorsRosI::MotorsRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_motors_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Motors");
 

--- a/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
+++ b/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
@@ -82,22 +82,22 @@ class SpatialRosI final : public rclcpp::Node
         std::shared_ptr<std_srvs::srv::Empty::Response> res);
 
     // Accelerometer
-    double linear_acceleration_variance_;
-    double last_accel_x_;
-    double last_accel_y_;
-    double last_accel_z_;
+    double linear_acceleration_variance_{0.0};
+    double last_accel_x_{0.0};
+    double last_accel_y_{0.0};
+    double last_accel_z_{0.0};
 
     // Gyroscope
-    double angular_velocity_variance_;
-    double last_gyro_x_;
-    double last_gyro_y_;
-    double last_gyro_z_;
+    double angular_velocity_variance_{0.0};
+    double last_gyro_x_{0.0};
+    double last_gyro_y_{0.0};
+    double last_gyro_z_{0.0};
 
     // Magnetometer
-    double magnetic_field_variance_;
-    double last_mag_x_;
-    double last_mag_y_;
-    double last_mag_z_;
+    double magnetic_field_variance_{0.0};
+    double last_mag_x_{0.0};
+    double last_mag_y_{0.0};
+    double last_mag_z_{0.0};
 
     void publishLatest();
 

--- a/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
+++ b/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
@@ -36,6 +36,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/magnetic_field.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_srvs/srv/empty.hpp>
 

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -152,7 +152,7 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
         cc_T4 = this->get_parameter("cc_t4").get_value<double>();
         cc_T5 = this->get_parameter("cc_t5").get_value<double>();
         has_compass_params = true;
-    } catch (const rclcpp::exceptions::ParameterNotDeclaredException)
+    } catch (const rclcpp::exceptions::ParameterNotDeclaredException &)
     {
     }
 

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -50,7 +50,7 @@ namespace phidgets {
 SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
     : rclcpp::Node("phidgets_spatial_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Spatial");
 

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -35,12 +35,12 @@
 #include <stdexcept>
 #include <thread>
 
-#include <sensor_msgs/msg/imu.h>
-#include <std_msgs/msg/bool.h>
-#include <std_srvs/srv/empty.h>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_srvs/srv/empty.hpp>
 
 #include "phidgets_api/spatial.hpp"
 #include "phidgets_spatial/spatial_ros_i.hpp"

--- a/phidgets_temperature/include/phidgets_temperature/temperature_ros_i.hpp
+++ b/phidgets_temperature/include/phidgets_temperature/temperature_ros_i.hpp
@@ -48,7 +48,7 @@ class TemperatureRosI final : public rclcpp::Node
   private:
     std::unique_ptr<Temperature> temperature_;
     std::mutex temperature_mutex_;
-    double last_temperature_reading_;
+    double last_temperature_reading_{0.0};
     bool got_first_data_;
 
     rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr temperature_pub_;

--- a/phidgets_temperature/src/temperature_ros_i.cpp
+++ b/phidgets_temperature/src/temperature_ros_i.cpp
@@ -43,7 +43,7 @@ namespace phidgets {
 TemperatureRosI::TemperatureRosI(const rclcpp::NodeOptions& options)
     : rclcpp::Node("phidgets_temperature_node", options)
 {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+    setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
 
     RCLCPP_INFO(get_logger(), "Starting Phidgets Temperature");
 


### PR DESCRIPTION
I ran clang-tidy against the codebase, and came up with the following small changes to fix the warnings it threw.  None of them are real bugs, but they are nice to have fixed.  @mintar , nothing urgent here, but review is (eventually) appreciated.