### PR TITLE
Switch the buildtoo_depend to ament_cmake_ros.

### DIFF
--- a/phidgets_accelerometer/package.xml
+++ b/phidgets_accelerometer/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_analog_inputs/package.xml
+++ b/phidgets_analog_inputs/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_api/package.xml
+++ b/phidgets_api/package.xml
@@ -16,7 +16,7 @@
   <author>Tully Foote</author>
   <author>Ivan Dryanovski</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>libphidget22</depend>
 

--- a/phidgets_digital_inputs/package.xml
+++ b/phidgets_digital_inputs/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_digital_outputs/package.xml
+++ b/phidgets_digital_outputs/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>phidgets_msgs</depend>

--- a/phidgets_gyroscope/package.xml
+++ b/phidgets_gyroscope/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_high_speed_encoder/package.xml
+++ b/phidgets_high_speed_encoder/package.xml
@@ -12,7 +12,7 @@
   <author email="geoffrey.viola@asirobots.com">Geoff Viola</author>
   <author email="jlblanco@ual.es">José-Luis Blanco Claraco</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>phidgets_msgs</depend>

--- a/phidgets_magnetometer/package.xml
+++ b/phidgets_magnetometer/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_motors/package.xml
+++ b/phidgets_motors/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>phidgets_msgs</depend>

--- a/phidgets_spatial/package.xml
+++ b/phidgets_spatial/package.xml
@@ -15,7 +15,7 @@
 
   <author email="ccnyroboticslab@gmail.com">Ivan Dryanovski</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>

--- a/phidgets_temperature/package.xml
+++ b/phidgets_temperature/package.xml
@@ -11,7 +11,7 @@
 
   <author>Chris Lalancette</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>phidgets_api</depend>
   <depend>rclcpp</depend>


### PR DESCRIPTION
This matches what we search for in the CMakeLists.txt,
and should fix build problems on the buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>