### PR TITLE
Use '=default' for default destructors.

### DIFF
--- a/phidgets_api/include/phidgets_api/analog_inputs.hpp
+++ b/phidgets_api/include/phidgets_api/analog_inputs.hpp
@@ -48,7 +48,7 @@ class AnalogInputs final
                           bool is_hub_port_device,
                           std::function<void(int, double)> input_handler);
 
-    ~AnalogInputs();
+    ~AnalogInputs() = default;
 
     int32_t getSerialNumber() const noexcept;
 

--- a/phidgets_api/include/phidgets_api/digital_inputs.hpp
+++ b/phidgets_api/include/phidgets_api/digital_inputs.hpp
@@ -48,7 +48,7 @@ class DigitalInputs
                            bool is_hub_port_device,
                            std::function<void(int, int)> input_handler);
 
-    ~DigitalInputs();
+    ~DigitalInputs() = default;
 
     int32_t getSerialNumber() const noexcept;
 

--- a/phidgets_api/include/phidgets_api/digital_outputs.hpp
+++ b/phidgets_api/include/phidgets_api/digital_outputs.hpp
@@ -46,7 +46,7 @@ class DigitalOutputs final
     explicit DigitalOutputs(int32_t serial_number, int hub_port,
                             bool is_hub_port_device);
 
-    ~DigitalOutputs();
+    ~DigitalOutputs() = default;
 
     int32_t getSerialNumber() const noexcept;
 

--- a/phidgets_api/include/phidgets_api/encoders.hpp
+++ b/phidgets_api/include/phidgets_api/encoders.hpp
@@ -48,7 +48,7 @@ class Encoders final
         int32_t serial_number, int hub_port, bool is_hub_port_device,
         std::function<void(int, int, double, int)> position_change_handler);
 
-    ~Encoders();
+    ~Encoders() = default;
 
     int32_t getSerialNumber() const noexcept;
 

--- a/phidgets_api/include/phidgets_api/motors.hpp
+++ b/phidgets_api/include/phidgets_api/motors.hpp
@@ -49,7 +49,7 @@ class Motors final
                     std::function<void(int, double)> duty_cycle_change_handler,
                     std::function<void(int, double)> back_emf_change_handler);
 
-    ~Motors();
+    ~Motors() = default;
 
     int32_t getSerialNumber() const noexcept;
 

--- a/phidgets_api/src/analog_inputs.cpp
+++ b/phidgets_api/src/analog_inputs.cpp
@@ -81,10 +81,6 @@ AnalogInputs::AnalogInputs(int32_t serial_number, int hub_port,
     }
 }
 
-AnalogInputs::~AnalogInputs()
-{
-}
-
 int32_t AnalogInputs::getSerialNumber() const noexcept
 {
     return ais_.at(0)->getSerialNumber();

--- a/phidgets_api/src/digital_inputs.cpp
+++ b/phidgets_api/src/digital_inputs.cpp
@@ -79,10 +79,6 @@ DigitalInputs::DigitalInputs(int32_t serial_number, int hub_port,
     }
 }
 
-DigitalInputs::~DigitalInputs()
-{
-}
-
 int32_t DigitalInputs::getSerialNumber() const noexcept
 {
     return dis_.at(0)->getSerialNumber();

--- a/phidgets_api/src/digital_outputs.cpp
+++ b/phidgets_api/src/digital_outputs.cpp
@@ -78,10 +78,6 @@ DigitalOutputs::DigitalOutputs(int32_t serial_number, int hub_port,
     }
 }
 
-DigitalOutputs::~DigitalOutputs()
-{
-}
-
 int32_t DigitalOutputs::getSerialNumber() const noexcept
 {
     return dos_.at(0)->getSerialNumber();

--- a/phidgets_api/src/encoders.cpp
+++ b/phidgets_api/src/encoders.cpp
@@ -78,10 +78,6 @@ Encoders::Encoders(
     }
 }
 
-Encoders::~Encoders()
-{
-}
-
 int32_t Encoders::getSerialNumber() const noexcept
 {
     return encs_.at(0)->getSerialNumber();

--- a/phidgets_api/src/motors.cpp
+++ b/phidgets_api/src/motors.cpp
@@ -78,10 +78,6 @@ Motors::Motors(int32_t serial_number, int hub_port, bool is_hub_port_device,
     }
 }
 
-Motors::~Motors()
-{
-}
-
 int32_t Motors::getSerialNumber() const noexcept
 {
     return motors_.at(0)->getSerialNumber();


### PR DESCRIPTION
Pointed out by clang-tidy.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

@mintar Really minor change, no rush on reviewing it.