### PR TITLE
Release build fixes

### DIFF
--- a/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
+++ b/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
@@ -98,10 +98,9 @@ AnalogInputsRosI::AnalogInputsRosI(const rclcpp::NodeOptions& options)
             snprintf(str, sizeof(str), "offset%02d", i);
             val_to_pubs_[i].offset = this->declare_parameter(str, 0.0);
 
-            char topicname[] = "analog_input00";
-            snprintf(topicname, sizeof(topicname), "analog_input%02d", i);
+            snprintf(str, sizeof(str), "analog_input%02d", i);
             val_to_pubs_[i].pub =
-                this->create_publisher<std_msgs::msg::Float64>(topicname, 1);
+                this->create_publisher<std_msgs::msg::Float64>(str, 1);
 
             ais_->setDataInterval(i, data_interval_ms);
         }

--- a/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
+++ b/phidgets_analog_inputs/src/analog_inputs_ros_i.cpp
@@ -77,7 +77,7 @@ AnalogInputsRosI::AnalogInputsRosI(const rclcpp::NodeOptions& options)
     // finished setting up.
     std::lock_guard<std::mutex> lock(ai_mutex_);
 
-    int n_in;
+    uint32_t n_in;
     try
     {
         ais_ = std::make_unique<AnalogInputs>(
@@ -86,10 +86,10 @@ AnalogInputsRosI::AnalogInputsRosI(const rclcpp::NodeOptions& options)
                       std::placeholders::_1, std::placeholders::_2));
 
         n_in = ais_->getInputCount();
-        RCLCPP_INFO(get_logger(), "Connected to serial %d, %d inputs",
+        RCLCPP_INFO(get_logger(), "Connected to serial %d, %u inputs",
                     ais_->getSerialNumber(), n_in);
         val_to_pubs_.resize(n_in);
-        for (int i = 0; i < n_in; i++)
+        for (uint32_t i = 0; i < n_in; i++)
         {
             char str[100];
             snprintf(str, sizeof(str), "gain%02d", i);
@@ -123,7 +123,7 @@ AnalogInputsRosI::AnalogInputsRosI(const rclcpp::NodeOptions& options)
         // will only publish when something changes (where "changes" is defined
         // by the libphidget22 library).  In that case, make sure to publish
         // once at the beginning to make sure there is *some* data.
-        for (int i = 0; i < n_in; ++i)
+        for (uint32_t i = 0; i < n_in; ++i)
         {
             publishLatest(i);
         }

--- a/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
+++ b/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
@@ -89,7 +89,7 @@ DigitalInputsRosI::DigitalInputsRosI(const rclcpp::NodeOptions& options)
         val_to_pubs_.resize(n_in);
         for (uint32_t i = 0; i < n_in; i++)
         {
-            char topicname[] = "digital_input00";
+            char topicname[100];
             snprintf(topicname, sizeof(topicname), "digital_input%02d", i);
             val_to_pubs_[i].pub =
                 this->create_publisher<std_msgs::msg::Bool>(topicname, 1);

--- a/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
+++ b/phidgets_digital_inputs/src/digital_inputs_ros_i.cpp
@@ -75,7 +75,7 @@ DigitalInputsRosI::DigitalInputsRosI(const rclcpp::NodeOptions& options)
     // finished setting up.
     std::lock_guard<std::mutex> lock(di_mutex_);
 
-    int n_in;
+    uint32_t n_in;
     try
     {
         dis_ = std::make_unique<DigitalInputs>(
@@ -84,10 +84,10 @@ DigitalInputsRosI::DigitalInputsRosI(const rclcpp::NodeOptions& options)
                       std::placeholders::_1, std::placeholders::_2));
 
         n_in = dis_->getInputCount();
-        RCLCPP_INFO(get_logger(), "Connected to serial %d, %d inputs",
+        RCLCPP_INFO(get_logger(), "Connected to serial %d, %u inputs",
                     dis_->getSerialNumber(), n_in);
         val_to_pubs_.resize(n_in);
-        for (int i = 0; i < n_in; i++)
+        for (uint32_t i = 0; i < n_in; i++)
         {
             char topicname[] = "digital_input00";
             snprintf(topicname, sizeof(topicname), "digital_input%02d", i);
@@ -113,7 +113,7 @@ DigitalInputsRosI::DigitalInputsRosI(const rclcpp::NodeOptions& options)
         // will only publish when something changes (where "changes" is defined
         // by the libphidget22 library).  In that case, make sure to publish
         // once at the beginning to make sure there is *some* data.
-        for (int i = 0; i < n_in; ++i)
+        for (uint32_t i = 0; i < n_in; ++i)
         {
             publishLatest(i);
         }

--- a/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
+++ b/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
@@ -80,7 +80,7 @@ DigitalOutputsRosI::DigitalOutputsRosI(const rclcpp::NodeOptions& options)
     out_subs_.resize(n_out);
     for (uint32_t i = 0; i < n_out; i++)
     {
-        char topicname[] = "digital_output00";
+        char topicname[100];
         snprintf(topicname, sizeof(topicname), "digital_output%02d", i);
         out_subs_[i] = std::make_unique<DigitalOutputSetter>(dos_.get(), i,
                                                              this, topicname);

--- a/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
+++ b/phidgets_digital_outputs/src/digital_outputs_ros_i.cpp
@@ -74,11 +74,11 @@ DigitalOutputsRosI::DigitalOutputsRosI(const rclcpp::NodeOptions& options)
         throw;
     }
 
-    int n_out = dos_->getOutputCount();
-    RCLCPP_INFO(get_logger(), "Connected to serial %d, %d outputs",
+    uint32_t n_out = dos_->getOutputCount();
+    RCLCPP_INFO(get_logger(), "Connected to serial %d, %u outputs",
                 dos_->getSerialNumber(), n_out);
     out_subs_.resize(n_out);
-    for (int i = 0; i < n_out; i++)
+    for (uint32_t i = 0; i < n_out; i++)
     {
         char topicname[] = "digital_output00";
         snprintf(topicname, sizeof(topicname), "digital_output%02d", i);

--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -79,7 +79,7 @@ HighSpeedEncoderRosI::HighSpeedEncoderRosI(const rclcpp::NodeOptions& options)
     // finished setting up.
     std::lock_guard<std::mutex> lock(encoder_mutex_);
 
-    int n_encs;
+    uint32_t n_encs;
     try
     {
         encs_ = std::make_unique<Encoders>(
@@ -89,10 +89,10 @@ HighSpeedEncoderRosI::HighSpeedEncoderRosI(const rclcpp::NodeOptions& options)
                       std::placeholders::_3, std::placeholders::_4));
 
         n_encs = encs_->getEncoderCount();
-        RCLCPP_INFO(get_logger(), "Connected to serial %d, %d encoders",
+        RCLCPP_INFO(get_logger(), "Connected to serial %d, %u encoders",
                     encs_->getSerialNumber(), n_encs);
         enc_data_to_pub_.resize(n_encs);
-        for (int i = 0; i < n_encs; i++)
+        for (uint32_t i = 0; i < n_encs; i++)
         {
             char str[100];
             sprintf(str, "joint%u_name", i);
@@ -136,7 +136,7 @@ HighSpeedEncoderRosI::HighSpeedEncoderRosI(const rclcpp::NodeOptions& options)
         // will only publish when something changes (where "changes" is defined
         // by the libphidget22 library).  In that case, make sure to publish
         // once at the beginning to make sure there is *some* data.
-        for (int i = 0; i < n_encs; ++i)
+        for (uint32_t i = 0; i < n_encs; ++i)
         {
             publishLatest(i);
         }

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -104,19 +104,19 @@ MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
     this->declare_parameter("cc_t5");
 
     bool has_compass_params = false;
-    double cc_mag_field;
-    double cc_offset0;
-    double cc_offset1;
-    double cc_offset2;
-    double cc_gain0;
-    double cc_gain1;
-    double cc_gain2;
-    double cc_T0;
-    double cc_T1;
-    double cc_T2;
-    double cc_T3;
-    double cc_T4;
-    double cc_T5;
+    double cc_mag_field = 0.0;
+    double cc_offset0 = 0.0;
+    double cc_offset1 = 0.0;
+    double cc_offset2 = 0.0;
+    double cc_gain0 = 0.0;
+    double cc_gain1 = 0.0;
+    double cc_gain2 = 0.0;
+    double cc_T0 = 0.0;
+    double cc_T1 = 0.0;
+    double cc_T2 = 0.0;
+    double cc_T3 = 0.0;
+    double cc_T4 = 0.0;
+    double cc_T5 = 0.0;
 
     try
     {

--- a/phidgets_motors/src/motors_ros_i.cpp
+++ b/phidgets_motors/src/motors_ros_i.cpp
@@ -74,7 +74,7 @@ MotorsRosI::MotorsRosI(const rclcpp::NodeOptions& options)
     // finished setting up.
     std::lock_guard<std::mutex> lock(motor_mutex_);
 
-    int n_motors;
+    uint32_t n_motors;
     try
     {
         motors_ = std::make_unique<Motors>(
@@ -85,11 +85,11 @@ MotorsRosI::MotorsRosI(const rclcpp::NodeOptions& options)
                       std::placeholders::_1, std::placeholders::_2));
 
         n_motors = motors_->getMotorCount();
-        RCLCPP_INFO(get_logger(), "Connected to serial %d, %d motors",
+        RCLCPP_INFO(get_logger(), "Connected to serial %d, %u motors",
                     motors_->getSerialNumber(), n_motors);
 
         motor_vals_.resize(n_motors);
-        for (int i = 0; i < n_motors; i++)
+        for (uint32_t i = 0; i < n_motors; i++)
         {
             char topicname[] = "set_motor_duty_cycle00";
             snprintf(topicname, sizeof(topicname), "set_motor_duty_cycle%02d",
@@ -139,7 +139,7 @@ MotorsRosI::MotorsRosI(const rclcpp::NodeOptions& options)
         // will only publish when something changes (where "changes" is defined
         // by the libphidget22 library).  In that case, make sure to publish
         // once at the beginning to make sure there is *some* data.
-        for (int i = 0; i < n_motors; ++i)
+        for (uint32_t i = 0; i < n_motors; ++i)
         {
             publishLatestDutyCycle(i);
             publishLatestBackEMF(i);

--- a/phidgets_motors/src/motors_ros_i.cpp
+++ b/phidgets_motors/src/motors_ros_i.cpp
@@ -91,31 +91,27 @@ MotorsRosI::MotorsRosI(const rclcpp::NodeOptions& options)
         motor_vals_.resize(n_motors);
         for (uint32_t i = 0; i < n_motors; i++)
         {
-            char topicname[] = "set_motor_duty_cycle00";
+            char topicname[100];
             snprintf(topicname, sizeof(topicname), "set_motor_duty_cycle%02d",
                      i);
             motor_vals_[i].duty_cycle_sub = std::make_unique<DutyCycleSetter>(
                 motors_.get(), i, this, topicname);
 
-            char pubtopic[] = "motor_duty_cycle00";
-            snprintf(pubtopic, sizeof(pubtopic), "motor_duty_cycle%02d", i);
+            snprintf(topicname, sizeof(topicname), "motor_duty_cycle%02d", i);
             motor_vals_[i].duty_cycle_pub =
-                this->create_publisher<std_msgs::msg::Float64>(pubtopic, 1);
+                this->create_publisher<std_msgs::msg::Float64>(topicname, 1);
             motor_vals_[i].last_duty_cycle_val = motors_->getDutyCycle(i);
 
-            char backemftopic[] = "motor_back_emf00";
-            snprintf(backemftopic, sizeof(backemftopic), "motor_back_emf%02d",
-                     i);
+            snprintf(topicname, sizeof(topicname), "motor_back_emf%02d", i);
             motor_vals_[i].back_emf_pub =
-                this->create_publisher<std_msgs::msg::Float64>(backemftopic, 1);
+                this->create_publisher<std_msgs::msg::Float64>(topicname, 1);
             if (motors_->backEMFSensingSupported(i))
             {
                 motor_vals_[i].last_back_emf_val = motors_->getBackEMF(i);
             } else
             {
                 RCLCPP_INFO(get_logger(),
-                            "Back EMF sensing not supported for %s",
-                            backemftopic);
+                            "Back EMF sensing not supported for %s", topicname);
             }
 
             motors_->setDataInterval(i, data_interval_ms);

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -122,19 +122,19 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
     this->declare_parameter("cc_t5");
 
     bool has_compass_params = false;
-    double cc_mag_field;
-    double cc_offset0;
-    double cc_offset1;
-    double cc_offset2;
-    double cc_gain0;
-    double cc_gain1;
-    double cc_gain2;
-    double cc_T0;
-    double cc_T1;
-    double cc_T2;
-    double cc_T3;
-    double cc_T4;
-    double cc_T5;
+    double cc_mag_field = 0.0;
+    double cc_offset0 = 0.0;
+    double cc_offset1 = 0.0;
+    double cc_offset2 = 0.0;
+    double cc_gain0 = 0.0;
+    double cc_gain1 = 0.0;
+    double cc_gain2 = 0.0;
+    double cc_T0 = 0.0;
+    double cc_T1 = 0.0;
+    double cc_T2 = 0.0;
+    double cc_T3 = 0.0;
+    double cc_T4 = 0.0;
+    double cc_T5 = 0.0;
 
     try
     {


### PR DESCRIPTION
Here is another small stack of patches to fix errors pointed out when building in release mode (passing `--cmake-args -DCMAKE_BUILD_TYPE=Release` to colcon).  Again, nothing urgent in here, but would be nice to get in.