### PR TITLE
Composite Design Pattern Discussion

### DIFF
--- a/phidgets_api/include/phidgets_api/phidget22.hpp
+++ b/phidgets_api/include/phidgets_api/phidget22.hpp
@@ -55,7 +55,7 @@ class Phidget22Error final : public std::exception
     std::string msg_;
 };
 
-struct ChannelInfo
+struct PhidgetInfo
 {
   int32_t serial_number{ PHIDGET_SERIALNUMBER_ANY };
   int hub_port{ PHIDGET_HUBPORT_ANY };
@@ -65,13 +65,6 @@ struct ChannelInfo
 
 class PhidgetComponent
 {
-public:
-  PhidgetComponent(std::string name);
-  virtual bool hasHandle() const override;
-  virtual void setOnAttachHandler(std::function<void(PhidgetHandle, void *)> on_attach_handler) override;
-private:
-  std::string name_;
-  void on_attach_handler();
 };
 
 class Phidget : public PhidgetComponent

--- a/phidgets_api/include/phidgets_api/phidget22.hpp
+++ b/phidgets_api/include/phidgets_api/phidget22.hpp
@@ -32,6 +32,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <functional>
 
 #include <libphidget22/phidget22.h>
 
@@ -52,6 +53,34 @@ class Phidget22Error final : public std::exception
 
   private:
     std::string msg_;
+};
+
+struct ChannelInfo
+{
+  int32_t serial_number{ PHIDGET_SERIALNUMBER_ANY };
+  int hub_port{ PHIDGET_HUBPORT_ANY };
+  bool is_hub_port_device{ false };
+  int channel{ PHIDGET_CHANNEL_ANY };
+};
+
+class PhidgetComponent
+{
+public:
+  PhidgetComponent(std::string name);
+  virtual bool hasHandle() const override;
+  virtual void setOnAttachHandler(std::function<void(PhidgetHandle, void *)> on_attach_handler) override;
+private:
+  std::string name_;
+  void on_attach_handler();
+};
+
+class Phidget : public PhidgetComponent
+{
+};
+
+class PhidgetComposite: public PhidgetComponent
+{
+
 };
 
 namespace helpers {


### PR DESCRIPTION
Hi. I finally have some more time to work on these drivers. I am opening this pull request just to discuss some possible changes I could make.

For some of my projects I need to use the Dashing distribution and make some breaking changes. That may mean I need to just keep my own fork and keep changes separate from this repository, at least for now. I would like to get your input, though, in case you want any changes, perhaps on future distributions.

After lots of experimenting with real hardware, I found that the [composite pattern](https://en.wikipedia.org/wiki/Composite_pattern) seems to work well with Phidgets. That way a collection of heterogeneous Phidgets is treated in a very similar way as a single Phidget. For example, a Stepper Phidget can be extended to a Stepper Joint Phidget composite, that includes both a home switch DigitalInput and an optional limit switch DigitalInput. The composite can be open and closed and queried just as if it was a single Phidget.

There are a couple of ways to implement the composite pattern. One way is just to live in the C++ classes world and create a PhidgetComponent base class that a Phidget class and a PhidgetComposite class both inherit from. Then all the Phidget callbacks are handled within those classes.

Another way to implement the composite pattern might be to push everything to the ROS abstraction layer and form a composite from a collection of ROS nodes rather than C++ classes directly. That seems to be more of the original intent of the drivers in this repository. Composing with nodes might add flexibility and transparency as to what is happening within the composite. It may have some performance penalties, though, of having Phidget callbacks send ROS messages which then trigger ROS callbacks instead of just using the Phidget callbacks directly.

Phidgets breaks apart systems into smaller pieces than most other controllers and sensors. Many other stepper controllers, for example, have home switch and limit switch inputs that are handled internally in the controller. This makes it a little harder to observe what is happening within the controller, but it improves the response times to the digital inputs significantly.

So implementing the composite design pattern with C++ classes is probably more similar to how other ROS drivers would be written and might have better performance. Implementing the composite design pattern with ROS nodes might be more general and people using these drivers might need to know less about Phidgets and use more ROS tools.

Do you have a preference on which approach would be better or is there yet another way that would be preferred? Do you have interest in me making changes to the dashing branch of this repository or should I keep everything in my own fork and you can decide if you want changes later in a future distribution once I have worked out more details? 