### PR TITLE
Get rid of deprecation warnings in Foxy.

### DIFF
--- a/phidgets_accelerometer/launch/accelerometer-launch.py
+++ b/phidgets_accelerometer/launch/accelerometer-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_accelerometer',
-                    node_plugin='phidgets::AccelerometerRosI',
-                    node_name='phidgets_accelerometer'),
+                    plugin='phidgets::AccelerometerRosI',
+                    name='phidgets_accelerometer'),
             ],
             output='both',
     )

--- a/phidgets_analog_inputs/launch/analog_inputs-launch.py
+++ b/phidgets_analog_inputs/launch/analog_inputs-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_analog_inputs',
-                    node_plugin='phidgets::AnalogInputsRosI',
-                    node_name='phidgets_analog_inputs'),
+                    plugin='phidgets::AnalogInputsRosI',
+                    name='phidgets_analog_inputs'),
             ],
             output='both',
     )

--- a/phidgets_digital_inputs/launch/digital_inputs-launch.py
+++ b/phidgets_digital_inputs/launch/digital_inputs-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_digital_inputs',
-                    node_plugin='phidgets::DigitalInputsRosI',
-                    node_name='phidgets_digital_inputs'),
+                    plugin='phidgets::DigitalInputsRosI',
+                    name='phidgets_digital_inputs'),
             ],
             output='both',
     )

--- a/phidgets_digital_outputs/launch/digital_outputs-launch.py
+++ b/phidgets_digital_outputs/launch/digital_outputs-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_digital_outputs',
-                    node_plugin='phidgets::DigitalOutputsRosI',
-                    node_name='phidgets_digital_outputs'),
+                    plugin='phidgets::DigitalOutputsRosI',
+                    name='phidgets_digital_outputs'),
             ],
             output='both',
     )

--- a/phidgets_gyroscope/launch/gyroscope-launch.py
+++ b/phidgets_gyroscope/launch/gyroscope-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_gyroscope',
-                    node_plugin='phidgets::GyroscopeRosI',
-                    node_name='phidgets_gyroscope'),
+                    plugin='phidgets::GyroscopeRosI',
+                    name='phidgets_gyroscope'),
             ],
             output='both',
     )

--- a/phidgets_high_speed_encoder/launch/high_speed_encoder-launch.py
+++ b/phidgets_high_speed_encoder/launch/high_speed_encoder-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_high_speed_encoder',
-                    node_plugin='phidgets::HighSpeedEncoderRosI',
-                    node_name='phidgets_high_speed_encoder'),
+                    plugin='phidgets::HighSpeedEncoderRosI',
+                    name='phidgets_high_speed_encoder'),
             ],
             output='both',
     )

--- a/phidgets_ik/launch/ik-launch.py
+++ b/phidgets_ik/launch/ik-launch.py
@@ -44,25 +44,25 @@ def generate_launch_description():
     }
 
     container = ComposableNodeContainer(
-            node_name='phidgets_ik',
-            node_namespace='',
+            name='phidgets_ik',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_digital_outputs',
-                    node_plugin='phidgets::DigitalOutputsRosI',
-                    node_name='phidgets_digital_outputs',
+                    plugin='phidgets::DigitalOutputsRosI',
+                    name='phidgets_digital_outputs',
                     parameters=[do_params]),
                 ComposableNode(
                     package='phidgets_digital_inputs',
-                    node_plugin='phidgets::DigitalInputsRosI',
-                    node_name='phidgets_digital_inputs',
+                    plugin='phidgets::DigitalInputsRosI',
+                    name='phidgets_digital_inputs',
                     parameters=[di_params]),
                 ComposableNode(
                     package='phidgets_analog_inputs',
-                    node_plugin='phidgets::AnalogInputsRosI',
-                    node_name='phidgets_analog_inputs',
+                    plugin='phidgets::AnalogInputsRosI',
+                    name='phidgets_analog_inputs',
                     parameters=[ai_params]),
             ],
             output='both',

--- a/phidgets_magnetometer/launch/magnetometer-launch.py
+++ b/phidgets_magnetometer/launch/magnetometer-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_magnetometer',
-                    node_plugin='phidgets::MagnetometerRosI',
-                    node_name='phidgets_magnetometer'),
+                    plugin='phidgets::MagnetometerRosI',
+                    name='phidgets_magnetometer'),
             ],
             output='both',
     )

--- a/phidgets_motors/launch/motors-launch.py
+++ b/phidgets_motors/launch/motors-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_motors',
-                    node_plugin='phidgets::MotorsRosI',
-                    node_name='phidgets_motors'),
+                    plugin='phidgets::MotorsRosI',
+                    name='phidgets_motors'),
             ],
             output='both',
     )

--- a/phidgets_spatial/launch/spatial-launch.py
+++ b/phidgets_spatial/launch/spatial-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_spatial',
-                    node_plugin='phidgets::SpatialRosI',
-                    node_name='phidgets_spatial'),
+                    plugin='phidgets::SpatialRosI',
+                    name='phidgets_spatial'),
             ],
             output='both',
     )

--- a/phidgets_temperature/launch/temperature-launch.py
+++ b/phidgets_temperature/launch/temperature-launch.py
@@ -22,15 +22,15 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     """Generate launch description with multiple components."""
     container = ComposableNodeContainer(
-            node_name='phidget_container',
-            node_namespace='',
+            name='phidget_container',
+            namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='phidgets_temperature',
-                    node_plugin='phidgets::TemperatureRosI',
-                    node_name='phidgets_temperature'),
+                    plugin='phidgets::TemperatureRosI',
+                    name='phidgets_temperature'),
             ],
             output='both',
     )


### PR DESCRIPTION
Foxy deprecated some of the names we use in the launch files.
Switch to the new supported names here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that I created a new branch "foxy" off of the dashing branch, since we'll have to release separately for foxy now.