### PR TITLE
clang-format: Don't sort includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,3 +10,4 @@ BraceWrapping:
   AfterFunction: true
   SplitEmptyFunction: true
 IndentWidth: 4
+SortIncludes: false


### PR DESCRIPTION
This is required because the default ordering changed between clang 6 (Ubuntu 18.04) and clang 10 (Ubuntu 20.04), and our includes are sorted the way clang 6 preferred.

This will make updating the Dockerfile to Foxy very straightforward, once the `ros:foxy-ros-core` Docker image is available. Without this commit, `clang-check-style.py` will report lots of style differences when run on Ubuntu 20.04.

I've tested this on noetic (which is also on Ubuntu 20.04).