### PR TITLE
Use private node handler for params.

### DIFF
--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -24,7 +24,8 @@ HighSpeedEncoderRosI::HighSpeedEncoderRosI(ros::NodeHandle nh,
         sprintf(str, "joint%u_tick2rad", i);
         nh_private_.getParam(str, joint_tick2rad_[i]);
 
-        ROS_INFO("Channel %u Name: '%s', Tick2rad: '%f'", i, joint_names_[i].c_str(), joint_tick2rad_[i]);
+        ROS_INFO("Channel %u Name: '%s', Tick2rad: '%f'", i,
+                 joint_names_[i].c_str(), joint_tick2rad_[i]);
     }
 
     int serial_number = -1;

--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -19,18 +19,18 @@ HighSpeedEncoderRosI::HighSpeedEncoderRosI(ros::NodeHandle nh,
     {
         char str[100];
         sprintf(str, "joint%u_name", i);
-        nh_.getParam(str, joint_names_[i]);
+        nh_private_.getParam(str, joint_names_[i]);
 
         sprintf(str, "joint%u_tick2rad", i);
-        nh_.getParam(str, joint_tick2rad_[i]);
+        nh_private_.getParam(str, joint_tick2rad_[i]);
 
-        ROS_INFO("Channel %u: '%s'='%s'", i, str, joint_names_[i].c_str());
+        ROS_INFO("Channel %u Name: '%s', Tick2rad: '%f'", i, joint_names_[i].c_str(), joint_tick2rad_[i]);
     }
 
     int serial_number = -1;
     if (serial_number == -1)
     {
-        nh_.getParam("serial_number", serial_number);
+        nh_private_.getParam("serial_number", serial_number);
     }
 
     nh_private_.getParam("frame_id", frame_id_);


### PR DESCRIPTION
I noticed that the high speed encoder library doesn't respect the parameters set in a launch file because they are supposed to private not public. This fix allows tick2rad and the serial number to be properly set for each channel. Also changed the printout for ROS_INFO about channel name to properly output desired information. 
```
[ INFO] [1592680369.498374641]: Channel 0 Name: 'back_left_wheel_joint', Tick2rad: '0.001088' 
```

This has been tested and works on our robot. 
Also, the phidgets wiki reference for parameters are outdated. They still reference 0.7.9 instead of new names in 0.7.10. In particular "serial_name" has been changed to "serial_number"