### PR TITLE
Log synchronization window details at DEBUG level

### DIFF
--- a/phidgets_accelerometer/src/accelerometer_ros_i.cpp
+++ b/phidgets_accelerometer/src/accelerometer_ros_i.cpp
@@ -253,7 +253,7 @@ void AccelerometerRosI::accelerometerChangeCallback(
             can_publish_ = true;
         } else
         {
-            RCLCPP_WARN(
+            RCLCPP_DEBUG(
                 get_logger(),
                 "Data not within acceptable window for synchronization: "
                 "expected between %ld and %ld, saw %ld",

--- a/phidgets_gyroscope/src/gyroscope_ros_i.cpp
+++ b/phidgets_gyroscope/src/gyroscope_ros_i.cpp
@@ -293,7 +293,7 @@ void GyroscopeRosI::gyroscopeChangeCallback(const double angular_rate[3],
             can_publish_ = true;
         } else
         {
-            RCLCPP_WARN(
+            RCLCPP_DEBUG(
                 get_logger(),
                 "Data not within acceptable window for synchronization: "
                 "expected between %ld and %ld, saw %ld",

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -312,7 +312,7 @@ void MagnetometerRosI::magnetometerChangeCallback(
             can_publish_ = true;
         } else
         {
-            RCLCPP_WARN(
+            RCLCPP_DEBUG(
                 get_logger(),
                 "Data not within acceptable window for synchronization: "
                 "expected between %ld and %ld, saw %ld",

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -399,7 +399,7 @@ void SpatialRosI::spatialDataCallback(const double acceleration[3],
             can_publish_ = true;
         } else
         {
-            RCLCPP_WARN(
+            RCLCPP_DEBUG(
                 get_logger(),
                 "Data not within acceptable window for synchronization: "
                 "expected between %ld and %ld, saw %ld",


### PR DESCRIPTION
The message is logged in quick succession at the callback rate until
synchronization succeeds.
This can lead to a lot of warning messages even though the
synchronization succeeds quickly.

The message is confusing for users that don't know the code context
(which is very well explained in the comments by the way).

Given that the message is logging an internal detail, I propose to
change the level to DEBUG.