### PR TITLE
Don't publish messages that jumped back in time.

### DIFF
--- a/phidgets_accelerometer/src/accelerometer_ros_i.cpp
+++ b/phidgets_accelerometer/src/accelerometer_ros_i.cpp
@@ -163,8 +163,9 @@ void AccelerometerRosI::publishLatest()
 
     if (time_in_ns < last_ros_stamp_ns_)
     {
-        ROS_WARN("Time went backwards (%lu < %lu)!", time_in_ns,
-                 last_ros_stamp_ns_);
+        ROS_WARN("Time went backwards (%lu < %lu)! Not publishing message.",
+                 time_in_ns, last_ros_stamp_ns_);
+        return;
     }
 
     last_ros_stamp_ns_ = time_in_ns;

--- a/phidgets_gyroscope/src/gyroscope_ros_i.cpp
+++ b/phidgets_gyroscope/src/gyroscope_ros_i.cpp
@@ -198,8 +198,9 @@ void GyroscopeRosI::publishLatest()
 
     if (time_in_ns < last_ros_stamp_ns_)
     {
-        ROS_WARN("Time went backwards (%lu < %lu)!", time_in_ns,
-                 last_ros_stamp_ns_);
+        ROS_WARN("Time went backwards (%lu < %lu)! Not publishing message.",
+                 time_in_ns, last_ros_stamp_ns_);
+        return;
     }
 
     last_ros_stamp_ns_ = time_in_ns;

--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -203,8 +203,9 @@ void MagnetometerRosI::publishLatest()
 
     if (time_in_ns < last_ros_stamp_ns_)
     {
-        ROS_WARN("Time went backwards (%lu < %lu)!", time_in_ns,
-                 last_ros_stamp_ns_);
+        ROS_WARN("Time went backwards (%lu < %lu)! Not publishing message.",
+                 time_in_ns, last_ros_stamp_ns_);
+        return;
     }
 
     last_ros_stamp_ns_ = time_in_ns;

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -273,8 +273,9 @@ void SpatialRosI::publishLatest()
 
     if (time_in_ns < last_ros_stamp_ns_)
     {
-        ROS_WARN("Time went backwards (%lu < %lu)!", time_in_ns,
-                 last_ros_stamp_ns_);
+        ROS_WARN("Time went backwards (%lu < %lu)! Not publishing message.",
+                 time_in_ns, last_ros_stamp_ns_);
+        return;
     }
 
     last_ros_stamp_ns_ = time_in_ns;


### PR DESCRIPTION
This is basically ensuring the same behavior as it is in Melodic with
the old sync logic ([see here](https://github.com/ros-drivers/phidgets_drivers/blob/ca16fca8fbcbba89da3445f56c0a0c326cb0e8ea/phidgets_imu/src/imu_ros_i.cpp#L255)).

The motivation of this old PR also applies here:
https://github.com/ros-drivers/phidgets_drivers/pull/26/