### PR TITLE
Compile libphidget22 with -fPIC

### DIFF
--- a/libphidget22/CMakeLists.txt
+++ b/libphidget22/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libphidget22)
 
 find_package(ament_cmake REQUIRED)
 
-set(extra_c_flags "-g -O2 -Wno-incompatible-pointer-types -Wno-deprecated-declarations -Wno-format-truncation")
+set(extra_c_flags "-g -O2 -Wno-incompatible-pointer-types -Wno-deprecated-declarations -Wno-format-truncation -fPIC")
 
 include(ExternalProject)
 ExternalProject_Add(EP_${PROJECT_NAME}


### PR DESCRIPTION
This seems to be unnecessary on some platforms, but for greater compatibility, it's best to specify it explicitly.

Should resolve build failures on the buildfarm for RHEL 8: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__libphidget22__rhel_8_x86_64__binary/