### PR TITLE
Make sure to declare the type while declaring the parameter.

### DIFF
--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -89,19 +89,19 @@ MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
 
     // compass correction params (see
     // http://www.phidgets.com/docs/1044_User_Guide)
-    this->declare_parameter("cc_mag_field");
-    this->declare_parameter("cc_offset0");
-    this->declare_parameter("cc_offset1");
-    this->declare_parameter("cc_offset2");
-    this->declare_parameter("cc_gain0");
-    this->declare_parameter("cc_gain1");
-    this->declare_parameter("cc_gain2");
-    this->declare_parameter("cc_t0");
-    this->declare_parameter("cc_t1");
-    this->declare_parameter("cc_t2");
-    this->declare_parameter("cc_t3");
-    this->declare_parameter("cc_t4");
-    this->declare_parameter("cc_t5");
+    this->declare_parameter<double>("cc_mag_field");
+    this->declare_parameter<double>("cc_offset0");
+    this->declare_parameter<double>("cc_offset1");
+    this->declare_parameter<double>("cc_offset2");
+    this->declare_parameter<double>("cc_gain0");
+    this->declare_parameter<double>("cc_gain1");
+    this->declare_parameter<double>("cc_gain2");
+    this->declare_parameter<double>("cc_t0");
+    this->declare_parameter<double>("cc_t1");
+    this->declare_parameter<double>("cc_t2");
+    this->declare_parameter<double>("cc_t3");
+    this->declare_parameter<double>("cc_t4");
+    this->declare_parameter<double>("cc_t5");
 
     bool has_compass_params = false;
     double cc_mag_field = 0.0;

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -107,19 +107,19 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
 
     // compass correction params (see
     // http://www.phidgets.com/docs/1044_User_Guide)
-    this->declare_parameter("cc_mag_field");
-    this->declare_parameter("cc_offset0");
-    this->declare_parameter("cc_offset1");
-    this->declare_parameter("cc_offset2");
-    this->declare_parameter("cc_gain0");
-    this->declare_parameter("cc_gain1");
-    this->declare_parameter("cc_gain2");
-    this->declare_parameter("cc_t0");
-    this->declare_parameter("cc_t1");
-    this->declare_parameter("cc_t2");
-    this->declare_parameter("cc_t3");
-    this->declare_parameter("cc_t4");
-    this->declare_parameter("cc_t5");
+    this->declare_parameter<double>("cc_mag_field");
+    this->declare_parameter<double>("cc_offset0");
+    this->declare_parameter<double>("cc_offset1");
+    this->declare_parameter<double>("cc_offset2");
+    this->declare_parameter<double>("cc_gain0");
+    this->declare_parameter<double>("cc_gain1");
+    this->declare_parameter<double>("cc_gain2");
+    this->declare_parameter<double>("cc_t0");
+    this->declare_parameter<double>("cc_t1");
+    this->declare_parameter<double>("cc_t2");
+    this->declare_parameter<double>("cc_t3");
+    this->declare_parameter<double>("cc_t4");
+    this->declare_parameter<double>("cc_t5");
 
     bool has_compass_params = false;
     double cc_mag_field = 0.0;


### PR DESCRIPTION
As of Galactic, it is required by default to declare the type
of the parameter.  This PR fixes it so that we declare the type.
Note that this is not backwards compatible with Foxy, so we'll
have to make a new branch to target Galactic.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should solve the warnings we are seeing on the buildfarm: https://build.ros2.org/job/Rdev__phidgets_drivers__ubuntu_focal_amd64/2/ .  Note that I made a new 'galactic' branch to target this to, as this will not be backwards compatible with Foxy.  Once this is approved, I'll update the branches on https://github.com/ros/rosdistro/blob/8bc979c0be0632affdebbff2ea48f281e861bcde/rolling/distribution.yaml#L1321 to point to the new branch.