### PR TITLE
Make the magnetometer corrections optional again.

### DIFF
--- a/phidgets_magnetometer/src/magnetometer_ros_i.cpp
+++ b/phidgets_magnetometer/src/magnetometer_ros_i.cpp
@@ -89,19 +89,19 @@ MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
 
     // compass correction params (see
     // http://www.phidgets.com/docs/1044_User_Guide)
-    this->declare_parameter<double>("cc_mag_field");
-    this->declare_parameter<double>("cc_offset0");
-    this->declare_parameter<double>("cc_offset1");
-    this->declare_parameter<double>("cc_offset2");
-    this->declare_parameter<double>("cc_gain0");
-    this->declare_parameter<double>("cc_gain1");
-    this->declare_parameter<double>("cc_gain2");
-    this->declare_parameter<double>("cc_t0");
-    this->declare_parameter<double>("cc_t1");
-    this->declare_parameter<double>("cc_t2");
-    this->declare_parameter<double>("cc_t3");
-    this->declare_parameter<double>("cc_t4");
-    this->declare_parameter<double>("cc_t5");
+    this->declare_parameter("cc_mag_field", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t3", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t4", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t5", rclcpp::PARAMETER_DOUBLE);
 
     bool has_compass_params = false;
     double cc_mag_field = 0.0;
@@ -134,7 +134,7 @@ MagnetometerRosI::MagnetometerRosI(const rclcpp::NodeOptions& options)
         cc_T4 = this->get_parameter("cc_t4").get_value<double>();
         cc_T5 = this->get_parameter("cc_t5").get_value<double>();
         has_compass_params = true;
-    } catch (const rclcpp::exceptions::ParameterNotDeclaredException&)
+    } catch (const rclcpp::exceptions::ParameterUninitializedException &)
     {
     }
 

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -107,19 +107,19 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
 
     // compass correction params (see
     // http://www.phidgets.com/docs/1044_User_Guide)
-    this->declare_parameter<double>("cc_mag_field");
-    this->declare_parameter<double>("cc_offset0");
-    this->declare_parameter<double>("cc_offset1");
-    this->declare_parameter<double>("cc_offset2");
-    this->declare_parameter<double>("cc_gain0");
-    this->declare_parameter<double>("cc_gain1");
-    this->declare_parameter<double>("cc_gain2");
-    this->declare_parameter<double>("cc_t0");
-    this->declare_parameter<double>("cc_t1");
-    this->declare_parameter<double>("cc_t2");
-    this->declare_parameter<double>("cc_t3");
-    this->declare_parameter<double>("cc_t4");
-    this->declare_parameter<double>("cc_t5");
+    this->declare_parameter("cc_mag_field", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_offset2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_gain2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t0", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t1", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t2", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t3", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t4", rclcpp::PARAMETER_DOUBLE);
+    this->declare_parameter("cc_t5", rclcpp::PARAMETER_DOUBLE);
 
     bool has_compass_params = false;
     double cc_mag_field = 0.0;
@@ -152,7 +152,7 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
         cc_T4 = this->get_parameter("cc_t4").get_value<double>();
         cc_T5 = this->get_parameter("cc_t5").get_value<double>();
         has_compass_params = true;
-    } catch (const rclcpp::exceptions::ParameterNotDeclaredException &)
+    } catch (const rclcpp::exceptions::ParameterUninitializedException &)
     {
     }
 


### PR DESCRIPTION
Previously, I had made the code do the following:

this->declare_parameter<double>("cc_mag_field")

which gets rid of a deprecation warning on Galactic.  Unfortunately,
this also makes the parameter required.  Instead, we can do
the following, which keeps the parameter optional but also
gets rid of the deprecation warning:

this->declare_parameter("cc_mag_field", rclcpp::PARAMETER_DOUBLE)

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #94 