### PR TITLE
Make sure libphidget22 library can be found. (#97)

### DIFF
--- a/libphidget22/CMakeLists.txt
+++ b/libphidget22/CMakeLists.txt
@@ -39,5 +39,8 @@ install(
 )
 
 ament_environment_hooks(env_hook/libphidget22_library_path.sh)
+set(ENV_VAR_NAME "LD_LIBRARY_PATH")
+set(ENV_VAR_VALUE "opt/libphidget22/lib")
+ament_environment_hooks(env_hook/libphidget22_library_path.dsv.in)
 
 ament_package(CONFIG_EXTRAS "cmake/libphidget22-extras.cmake.in")

--- a/libphidget22/env_hook/libphidget22_library_path.dsv.in
+++ b/libphidget22/env_hook/libphidget22_library_path.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate;@ENV_VAR_NAME@;@ENV_VAR_VALUE@


### PR DESCRIPTION
In Foxy and later, we need to provide the .dsv hook so that
the library can be found.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is the same fix as #97, but for Galactic.