### PR TITLE
spatial: Fix publishing of invalid mag readings

### DIFF
--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -423,11 +423,27 @@ void SpatialRosI::spatialDataCallback(const double acceleration[3],
         last_gyro_y_ = angular_rate[1] * (M_PI / 180.0);
         last_gyro_z_ = angular_rate[2] * (M_PI / 180.0);
 
-        // device reports data in Gauss, multiply by 1e-4 to convert to Tesla
-        last_mag_x_ = magnetic_field[0] * 1e-4;
-        last_mag_y_ = magnetic_field[1] * 1e-4;
-        last_mag_z_ = magnetic_field[2] * 1e-4;
+        if (magnetic_field[0] != PUNK_DBL)
+        {
+            // device reports data in Gauss, multiply by 1e-4 to convert to
+            // Tesla
+            last_mag_x_ = magnetic_field[0] * 1e-4;
+            last_mag_y_ = magnetic_field[1] * 1e-4;
+            last_mag_z_ = magnetic_field[2] * 1e-4;
+        } else
+        {
+            // data is PUNK_DBL ("unknown double"), which means the magnetometer
+            // did not return valid readings. When publishing at 250 Hz, this
+            // will happen in every second message, because the magnetometer can
+            // only sample at 125 Hz. It is still important to publish these
+            // messages, because a downstream node sometimes uses a
+            // TimeSynchronizer to get Imu and Magnetometer nodes.
+            double nan = std::numeric_limits<double>::quiet_NaN();
 
+            last_mag_x_ = nan;
+            last_mag_y_ = nan;
+            last_mag_z_ = nan;
+        }
         last_data_timestamp_ns_ = this_ts_ns;
 
         // Publish if we aren't publishing on a timer


### PR DESCRIPTION
At high data rates (e.g., the default of 250 Hz), the magnetometer readings for every second message are invalid. The libphidget library marks these values with PUNK_DBL (== 1e300). Because we multiply with 1e-4, this lead to the output at the end of this message.

The sensor_msgs/MagneticField message specifies that unreported readings should be marked with "NaN". That is what this commit does.

Note that we do want to keep publishing these messages to enable a downstream node (e.g., imu_filter_madgwick) to use a TimeSynchronizer to synchronize between MagneticField and Imu messages.

This bug was introduced in eaa6fa95; this commit restores the behavior to the one before that commit.

----------------------------------------------------------------------

Example output before this commit:

    header:
      seq: 1999
      stamp:
        secs: 1644940759
        nsecs: 317582657
      frame_id: "imu_link"
    magnetic_field:
      x: 4.8177e-05
      y: -2.5149e-05
      z: 1.1514000000000002e-05
    magnetic_field_covariance: [1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14]
    ---
    header:
      seq: 2000
      stamp:
        secs: 1644940759
        nsecs: 321582657
      frame_id: "imu_link"
    magnetic_field:
      x: 1.0000000000000002e+296
      y: 1.0000000000000002e+296
      z: 1.0000000000000002e+296
    magnetic_field_covariance: [1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14]
    ---
    header:
      seq: 2001
      stamp:
        secs: 1644940759
        nsecs: 325582657
      frame_id: "imu_link"
    magnetic_field:
      x: 4.8177e-05
      y: -2.5149e-05
      z: 1.1211e-05
    magnetic_field_covariance: [1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14]
    ---
    ^Cheader:
      seq: 2002
      stamp:
        secs: 1644940759
        nsecs: 329582657
      frame_id: "imu_link"
    magnetic_field:
      x: 1.0000000000000002e+296
      y: 1.0000000000000002e+296
      z: 1.0000000000000002e+296
    magnetic_field_covariance: [1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14, 0.0, 0.0, 0.0, 1.2100000000000002e-14]