### PR TITLE
[foxy] spatial: Fix behavior after USB reattachment

### DIFF
--- a/phidgets_api/include/phidgets_api/spatial.hpp
+++ b/phidgets_api/include/phidgets_api/spatial.hpp
@@ -47,7 +47,9 @@ class Spatial final
                      bool is_hub_port_device,
                      std::function<void(const double[3], const double[3],
                                         const double[3], double)>
-                         data_handler);
+                         data_handler,
+                     std::function<void()> attach_handler = nullptr,
+                     std::function<void()> detach_handler = nullptr);
 
     ~Spatial();
 
@@ -67,18 +69,25 @@ class Spatial final
 
     void dataHandler(const double acceleration[3], const double angular_rate[3],
                      const double magnetic_field[3], double timestamp) const;
+    virtual void attachHandler();
+    virtual void detachHandler();
 
   private:
     int32_t serial_number_;
     std::function<void(const double[3], const double[3], const double[3],
                        double)>
         data_handler_;
+    std::function<void()> attach_handler_;
+    std::function<void()> detach_handler_;
+
     PhidgetSpatialHandle spatial_handle_{nullptr};
 
     static void DataHandler(PhidgetSpatialHandle input_handle, void *ctx,
                             const double acceleration[3],
                             const double angular_rate[3],
                             const double magnetic_field[3], double timestamp);
+    static void AttachHandler(PhidgetHandle input_handle, void *ctx);
+    static void DetachHandler(PhidgetHandle input_handle, void *ctx);
 };
 
 }  // namespace phidgets

--- a/phidgets_api/src/spatial.cpp
+++ b/phidgets_api/src/spatial.cpp
@@ -28,9 +28,7 @@
  */
 
 #include <functional>
-#include <memory>
-#include <stdexcept>
-#include <string>
+#include <utility>
 
 #include <libphidget22/phidget22.h>
 
@@ -43,7 +41,7 @@ Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
                  std::function<void(const double[3], const double[3],
                                     const double[3], double)>
                      data_handler)
-    : serial_number_(serial_number), data_handler_(data_handler)
+    : serial_number_(serial_number), data_handler_(std::move(data_handler))
 {
     PhidgetReturnCode ret = PhidgetSpatial_create(&spatial_handle_);
     if (ret != EPHIDGET_OK)
@@ -76,7 +74,7 @@ Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
 
 Spatial::~Spatial()
 {
-    PhidgetHandle handle = reinterpret_cast<PhidgetHandle>(spatial_handle_);
+    auto handle = reinterpret_cast<PhidgetHandle>(spatial_handle_);
     helpers::closeAndDelete(&handle);
 }
 

--- a/phidgets_api/src/spatial.cpp
+++ b/phidgets_api/src/spatial.cpp
@@ -40,8 +40,13 @@ namespace phidgets {
 Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
                  std::function<void(const double[3], const double[3],
                                     const double[3], double)>
-                     data_handler)
-    : serial_number_(serial_number), data_handler_(std::move(data_handler))
+                     data_handler,
+                 std::function<void()> attach_handler,
+                 std::function<void()> detach_handler)
+    : serial_number_(serial_number),
+      data_handler_(std::move(data_handler)),
+      attach_handler_(std::move(attach_handler)),
+      detach_handler_(std::move(detach_handler))
 {
     PhidgetReturnCode ret = PhidgetSpatial_create(&spatial_handle_);
     if (ret != EPHIDGET_OK)
@@ -58,6 +63,30 @@ Spatial::Spatial(int32_t serial_number, int hub_port, bool is_hub_port_device,
     if (ret != EPHIDGET_OK)
     {
         throw Phidget22Error("Failed to set change handler for Spatial", ret);
+    }
+
+    if (attach_handler_ != nullptr)
+    {
+        ret = Phidget_setOnAttachHandler(
+            reinterpret_cast<PhidgetHandle>(spatial_handle_), AttachHandler,
+            this);
+        if (ret != EPHIDGET_OK)
+        {
+            throw Phidget22Error("Failed to set attach handler for Spatial",
+                                 ret);
+        }
+    }
+
+    if (detach_handler_ != nullptr)
+    {
+        ret = Phidget_setOnDetachHandler(
+            reinterpret_cast<PhidgetHandle>(spatial_handle_), DetachHandler,
+            this);
+        if (ret != EPHIDGET_OK)
+        {
+            throw Phidget22Error("Failed to set detach handler for Spatial",
+                                 ret);
+        }
     }
 
     if (serial_number_ == -1)
@@ -126,6 +155,16 @@ void Spatial::dataHandler(const double acceleration[3],
     data_handler_(acceleration, angular_rate, magnetic_field, timestamp);
 }
 
+void Spatial::attachHandler()
+{
+    attach_handler_();
+}
+
+void Spatial::detachHandler()
+{
+    detach_handler_();
+}
+
 void Spatial::DataHandler(PhidgetSpatialHandle /* input_handle */, void *ctx,
                           const double acceleration[3],
                           const double angular_rate[3],
@@ -133,6 +172,16 @@ void Spatial::DataHandler(PhidgetSpatialHandle /* input_handle */, void *ctx,
 {
     (reinterpret_cast<Spatial *>(ctx))
         ->dataHandler(acceleration, angular_rate, magnetic_field, timestamp);
+}
+
+void Spatial::AttachHandler(PhidgetHandle /* input_handle */, void *ctx)
+{
+    ((Spatial *)ctx)->attachHandler();
+}
+
+void Spatial::DetachHandler(PhidgetHandle /* input_handle */, void *ctx)
+{
+    ((Spatial *)ctx)->detachHandler();
 }
 
 }  // namespace phidgets

--- a/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
+++ b/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
@@ -105,6 +105,8 @@ class SpatialRosI final : public rclcpp::Node
     void spatialDataCallback(const double acceleration[3],
                              const double angular_rate[3],
                              const double magnetic_field[3], double timestamp);
+    void attachCallback();
+    void detachCallback();
 };
 
 }  // namespace phidgets

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -470,6 +470,16 @@ void SpatialRosI::spatialDataCallback(const double acceleration[3],
 void SpatialRosI::attachCallback()
 {
     RCLCPP_INFO(get_logger(), "Phidget Spatial attached.");
+
+    // Set data interval. This is in attachCallback() because it has to be
+    // repeated on reattachment.
+    spatial_->setDataInterval(data_interval_ns_ / 1000 / 1000);
+
+    // Force resynchronization, because the device time is reset to 0 after
+    // reattachment.
+    synchronize_timestamps_ = true;
+    can_publish_ = false;
+    last_cb_time_ = rclcpp::Time(0);
 }
 
 void SpatialRosI::detachCallback()

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -171,7 +171,9 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
             serial_num, hub_port, false,
             std::bind(&SpatialRosI::spatialDataCallback, this,
                       std::placeholders::_1, std::placeholders::_2,
-                      std::placeholders::_3, std::placeholders::_4));
+                      std::placeholders::_3, std::placeholders::_4),
+            std::bind(&SpatialRosI::attachCallback, this),
+            std::bind(&SpatialRosI::detachCallback, this));
 
         RCLCPP_INFO(get_logger(), "Connected to serial %d",
                     spatial_->getSerialNumber());
@@ -463,6 +465,16 @@ void SpatialRosI::spatialDataCallback(const double acceleration[3],
     }
 
     last_cb_time_ = now;
+}
+
+void SpatialRosI::attachCallback()
+{
+    RCLCPP_INFO(get_logger(), "Phidget Spatial attached.");
+}
+
+void SpatialRosI::detachCallback()
+{
+    RCLCPP_INFO(get_logger(), "Phidget Spatial detached.");
 }
 
 }  // namespace phidgets


### PR DESCRIPTION
The Phidged Spatial never recovered after detaching and reattaching to the USB port. This commit fixes that.

The cause of the failure was the following:

* After reattachment, the device time stamp restarts from 0. This caused our driver to throw the following error messages:

       [ WARN]: Time went backwards [...]! Not publishing message.

* However, the data interval is also reset to the default of 256 ms. If the parameter data_interval_ms is set to something else, this caused the arriving data to always be outside the acceptable window for synchronization. Therefore, synchronization never happened, and the driver never resumed publishing messages.

This commit fixes the bug by setting the appropriate data interval after each reattachment and forcing a resynchronization immediately.