### PR TITLE
CI: Replace noetic -> matrix.rosdistro

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         sudo rosdep init
         rosdep update
-        rosdep install --from-paths src -i -y --rosdistro noetic
+        rosdep install --from-paths src -i -y --rosdistro ${{ matrix.rosdistro }}
     - name: Build
       run: |
         . /opt/ros/${{ matrix.rosdistro }}/setup.sh


### PR DESCRIPTION
Tiny fix for the CI config. Also allows us to check whether PRs are now building properly. :)