### PR TITLE
Add in humble to the test matrix.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [rolling]
+        rosdistro: [rolling, humble]
       fail-fast: false
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
That way we will test incoming PRs on both Rolling and Humble.
We'll maintain this situation until we run into a situation
where Rolling and Humble need to diverge.  This commit
should be fast-forwarded onto the humble branch.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>