### PR TITLE
BUGFIX: Wrong speed conversion factor

### DIFF
--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -230,7 +230,7 @@ void HighSpeedEncoderRosI::positionChangeHandler(int channel,
     {
         std::lock_guard<std::mutex> lock(encoder_mutex_);
 
-        double instantaneous_speed = position_change / (time * 1e-6);
+        double instantaneous_speed = position_change / (time * 1e-3);
         enc_data_to_pub_[channel].instantaneous_speed = instantaneous_speed;
         enc_data_to_pub_[channel].speeds_buffer.push_back(instantaneous_speed);
         enc_data_to_pub_[channel].speed_buffer_updated = true;


### PR DESCRIPTION
The current code assumed time intervals from the Phisgets API was microseconds, but it's actually milliseconds. Reported speeds are all wrong by a factor of 1e3.

This is a forward-port of #155 to ROS2 galactic.