### PR TITLE
BUGFIX: Z-channel index was not observed in reported positions

### DIFF
--- a/phidgets_high_speed_encoder/include/phidgets_high_speed_encoder/high_speed_encoder_ros_i.hpp
+++ b/phidgets_high_speed_encoder/include/phidgets_high_speed_encoder/high_speed_encoder_ros_i.hpp
@@ -68,8 +68,8 @@ class HighSpeedEncoderRosI final : public rclcpp::Node
     /// (Default=10) Number of samples for the sliding window average filter of
     /// speeds.
     int speed_filter_samples_len_ = 10;
-    /// (Default=1) Number of "ITERATE" loops without any new encoder tick before
-    /// resetting the filtered average velocities.
+    /// (Default=1) Number of "ITERATE" loops without any new encoder tick
+    /// before resetting the filtered average velocities.
     int speed_filter_idle_iter_loops_before_reset_ = 1;
 
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr encoder_pub_;

--- a/phidgets_high_speed_encoder/include/phidgets_high_speed_encoder/high_speed_encoder_ros_i.hpp
+++ b/phidgets_high_speed_encoder/include/phidgets_high_speed_encoder/high_speed_encoder_ros_i.hpp
@@ -65,12 +65,12 @@ class HighSpeedEncoderRosI final : public rclcpp::Node
     /// Size of this vector = number of found encoders.
     std::vector<EncoderDataToPub> enc_data_to_pub_;
     std::string frame_id_;
-    // (Default=10) Number of samples for the sliding window average filter of
-    // speeds.
-    int speed_filter_samples_len_;
-    // (Default=1) Number of "ITERATE" loops without any new encoder tick before
-    // resetting the filtered average velocities.
-    int speed_filter_idle_iter_loops_before_reset_;
+    /// (Default=10) Number of samples for the sliding window average filter of
+    /// speeds.
+    int speed_filter_samples_len_ = 10;
+    /// (Default=1) Number of "ITERATE" loops without any new encoder tick before
+    /// resetting the filtered average velocities.
+    int speed_filter_idle_iter_loops_before_reset_ = 1;
 
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr encoder_pub_;
     void timerCallback();

--- a/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
+++ b/phidgets_high_speed_encoder/src/high_speed_encoder_ros_i.cpp
@@ -160,7 +160,8 @@ void HighSpeedEncoderRosI::publishLatest()
 
     for (size_t encIdx = 0; encIdx < numEncoders; ++encIdx)
     {
-        int64_t absolute_position = encs_->getPosition(encIdx);
+        int64_t absolute_position =
+            encs_->getPosition(encIdx) - encs_->getIndexPosition(encIdx);
 
         js_msg->position[encIdx] =
             absolute_position * enc_data_to_pub_[encIdx].joint_tick2rad;
@@ -224,9 +225,10 @@ void HighSpeedEncoderRosI::timerCallback()
 void HighSpeedEncoderRosI::positionChangeHandler(int channel,
                                                  int position_change,
                                                  double time,
-                                                 int /* index_triggered */)
+                                                 int /*index_triggered*/)
 {
-    if (static_cast<int>(enc_data_to_pub_.size()) > channel)
+    if (channel >= static_cast<int>(enc_data_to_pub_.size())) return;
+
     {
         std::lock_guard<std::mutex> lock(encoder_mutex_);
 


### PR DESCRIPTION
For encoders with the Z-channel correctly wired to the Phidgets board, the incremental encoder positions were reported without taking into account the passes through zero, effectively ignoring the Z-channel effect.

This only affected positions, not velocities.

PS: As usual, the same patch should be applied to all branches...