### PR TITLE
CI: Update to actions/checkout@v4 (ROS1)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install pip dependencies
       run: pip install pre-commit
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src/phidgets_drivers
     - name: Use rosdep to install remaining dependencies


### PR DESCRIPTION
This fixes the following warning:

    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.