### PR TITLE
CI: Add tmate debugging

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,5 +1,14 @@
 name: Build and run ROS tests
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 jobs:
   build:
     strategy:
@@ -9,6 +18,12 @@ jobs:
     container:
       image: ros:${{ matrix.rosdistro }}-ros-core
     steps:
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+      with:
+        detached: true
     - name: Install apt dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
This commit adds the option of running the GitHub workflow manually
(workflow_dispatch) and optionally enable tmate for SSH debugging.