### PR TITLE
Set CMake policy CMP0135

### DIFF
--- a/libphidget22/CMakeLists.txt
+++ b/libphidget22/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+cmake_policy(SET CMP0135 NEW)    # https://cmake.org/cmake/help/latest/policy/CMP0135.html
 project(libphidget22)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
This hopefully fixes the following error on ROS2 Rolling (Ubuntu 24.04):

    The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is...

See https://build.ros2.org/job/Rdev__phidgets_drivers__ubuntu_noble_amd64/4/cmake/