### PR TITLE
CI: Update test matrix

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [rolling, humble, iron]
+        rosdistro: [rolling, humble, jazzy, kilted]
       fail-fast: false
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [rolling, humble, jazzy, kilted]
+        rosdistro: [humble, jazzy, rolling]
       fail-fast: false
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Dropping `iron` because it's end-of-life (so the rosdep keys don't resolve any more), and adding `jazzy`.