### PR TITLE
CI: Add kilted

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [humble, jazzy, rolling]
+        rosdistro: [humble, jazzy, kilted, rolling]
       fail-fast: false
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
The Docker images for Kilted are available since the Kilted release this week.