### PR TITLE
CI: Drop humble from rosdistro matrix

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [humble, jazzy, kilted, rolling]
+        rosdistro: [jazzy, kilted, rolling]
       fail-fast: false
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Humble doesn't support the planned changes to the CMakeLists (#191), so we have to split off the jazzy/kilted/rolling branches from humble here.