### PR TITLE
Remove unnecessary linking to component_manager.

### DIFF
--- a/phidgets_accelerometer/CMakeLists.txt
+++ b/phidgets_accelerometer/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(phidgets_accelerometer PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_analog_inputs/CMakeLists.txt
+++ b/phidgets_analog_inputs/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(phidgets_analog_inputs PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_analog_inputs

--- a/phidgets_analog_outputs/CMakeLists.txt
+++ b/phidgets_analog_outputs/CMakeLists.txt
@@ -28,7 +28,6 @@ target_link_libraries(phidgets_analog_outputs PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_analog_outputs

--- a/phidgets_digital_inputs/CMakeLists.txt
+++ b/phidgets_digital_inputs/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(phidgets_digital_inputs PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_digital_inputs

--- a/phidgets_digital_outputs/CMakeLists.txt
+++ b/phidgets_digital_outputs/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(phidgets_digital_outputs PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_digital_outputs

--- a/phidgets_gyroscope/CMakeLists.txt
+++ b/phidgets_gyroscope/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(phidgets_gyroscope PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_high_speed_encoder/CMakeLists.txt
+++ b/phidgets_high_speed_encoder/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(phidgets_high_speed_encoder PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_magnetometer/CMakeLists.txt
+++ b/phidgets_magnetometer/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(phidgets_magnetometer PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_motors/CMakeLists.txt
+++ b/phidgets_motors/CMakeLists.txt
@@ -27,7 +27,6 @@ target_link_libraries(phidgets_motors PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_motors

--- a/phidgets_spatial/CMakeLists.txt
+++ b/phidgets_spatial/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(phidgets_spatial PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_stepper/CMakeLists.txt
+++ b/phidgets_stepper/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(phidgets_stepper PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
   sensor_msgs::sensor_msgs_library
 )
 

--- a/phidgets_temperature/CMakeLists.txt
+++ b/phidgets_temperature/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(phidgets_temperature PUBLIC
   phidgets_api::phidgets_api
   rclcpp::rclcpp
   rclcpp_components::component
-  rclcpp_components::component_manager
 )
 
 rclcpp_components_register_nodes(phidgets_temperature


### PR DESCRIPTION
These libraries are components themselves, and never need any parts of component_manager.  So just remove this dependency.

@mintar This is a follow-up to https://github.com/ros-drivers/phidgets_drivers/pull/191 (apologies that I did not respond at the time you opened it).

On a separate but related note, given that Noetic is now End-of-Life, would you mind if we made the default branch for this repository `rolling`?